### PR TITLE
Fix some errors and omissions in type declarations needed by geckolib animation_utils plugin

### DIFF
--- a/types/animation.d.ts
+++ b/types/animation.d.ts
@@ -117,6 +117,7 @@ interface AddChannelOptions {
 }
 declare class GeneralAnimator {
     constructor(uuid: string, animation: _Animation, name: string)
+    uuid: string
     keyframes: _Keyframe[]
     select(): this
     addToTimeline(): this

--- a/types/animation.d.ts
+++ b/types/animation.d.ts
@@ -5,6 +5,7 @@ declare class AnimationItem {
 
 interface AnimationOptions {
     name?: string
+    path?: string
     loop?: 'once' | 'hold' | 'loop'
     override?: boolean
     anim_time_update?: string
@@ -34,7 +35,7 @@ declare class _Animation extends AnimationItem {
     save(): this | undefined;
     select(): this | undefined;
     setLength(length: number): void;
-    createUniqueName(references: Animation[]): any;
+    createUniqueName(references: _Animation[]): any;
     rename(): this;
     togglePlayingState(state: any): any;
     showContextMenu(event: any): this;
@@ -46,7 +47,7 @@ declare class _Animation extends AnimationItem {
      * Adds the animation to the current project and to the interface
      * @param undo If true, the addition of the animation will be registered as an edit
      */
-    add(undo: any): this;
+    add(undo?: any): this;
     remove(undo: any, remove_from_file?: boolean): this;
     getMaxLength(): number;
     setLoop(value: any, undo: any): void;
@@ -86,6 +87,7 @@ declare class _Animation extends AnimationItem {
 declare namespace Animator {
     const open: boolean
     const MolangParser: object
+    const possible_channels: unknown[];
     const motion_trail: THREE.Object3D
     const motion_trail_lock: boolean
     const particle_effects: object
@@ -114,13 +116,13 @@ interface AddChannelOptions {
     max_data_points?: number
 }
 declare class GeneralAnimator {
-    constructor(uuid: string, animation: Animation)
-    keyframes: Keyframe[]
+    constructor(uuid: string, animation: _Animation, name: string)
+    keyframes: _Keyframe[]
     select(): this
     addToTimeline(): this
-    addKeyframe(data: KeyframeOptions, uuid: string): Keyframe
-    createKeyframe(): Keyframe
-    getOrMakeKeyframe(): {before: Keyframe, result: Keyframe}
+    addKeyframe(data: KeyframeOptions, uuid?: string): _Keyframe
+    createKeyframe(): _Keyframe
+    getOrMakeKeyframe(): {before: _Keyframe, result: _Keyframe}
     toggleMuted(channel: string): this
     scrollTo(): this
 
@@ -130,9 +132,9 @@ declare class GeneralAnimator {
 declare class BoneAnimator extends GeneralAnimator {
     name: string
     uuid: string
-    rotations: Keyframe[]
-    position: Keyframe[]
-    scale: Keyframe[]
+    rotations: _Keyframe[]
+    position: _Keyframe[]
+    scale: _Keyframe[]
     getGroup(): Group
     fillValues(): void
     pushKeyframe(): void
@@ -146,9 +148,9 @@ declare class BoneAnimator extends GeneralAnimator {
 declare class NullObjectAnimator extends GeneralAnimator {
     name: string
     uuid: string
-    rotations: Keyframe[]
-    position: Keyframe[]
-    scale: Keyframe[]
+    rotations: _Keyframe[]
+    position: _Keyframe[]
+    scale: _Keyframe[]
     getElement(): NullObject
     doRender(): void
     displayPosition(): void
@@ -156,11 +158,12 @@ declare class NullObjectAnimator extends GeneralAnimator {
     displayFrame(): void
 }
 declare class EffectAnimator extends GeneralAnimator {
+    constructor(animation: _Animation)
     name: string
     uuid: string
-    particle: Keyframe[]
-    sound: Keyframe[]
-    timeline: Keyframe[]
+    particle: _Keyframe[]
+    sound: _Keyframe[]
+    timeline: _Keyframe[]
     pushKeyframe(keyframe): this
     displayFrame(in_loop): this
     startPreviousSounds(): void

--- a/types/animation_controller.d.ts
+++ b/types/animation_controller.d.ts
@@ -63,7 +63,7 @@ declare class AnimationControllerState {
     remove(undo?: boolean): void
     createUniqueName(): void
 
-    addAnimation(animation?: Animation): void
+    addAnimation(animation?: _Animation): void
     addTransition(target_uuid?: string): void
     addParticle(options?: {effect: string}): void
     addSound(options?: {effect: string, file: string}): void

--- a/types/blockbench.d.ts
+++ b/types/blockbench.d.ts
@@ -35,7 +35,9 @@
 /// <reference types="./display_mode" />
 /// <reference types="./misc" />
 /// <reference types="./util" />
+/// <reference types="./math_util" />
 /// <reference types="./canvas_frame" />
+/// <reference types="./io" />
 
 
 	
@@ -248,7 +250,7 @@ declare namespace Blockbench {
 	/**
 	 * Removes an event listener
 	 */
-	export function removeListener(event_names: EventName): void
+	export function removeListener(event_names: EventName, callback: (data: object) => void): void
 
 
 

--- a/types/dialog.d.ts
+++ b/types/dialog.d.ts
@@ -9,6 +9,7 @@ interface DialogFormElement {
 	/** Add buttons to allow copying and sharing the text or link */
 	share_text?: boolean
 	value?: any
+	default?: any
 	placeholder?: string
 	text?: string
 	editable_range_label?: boolean
@@ -97,6 +98,7 @@ interface DialogOptions {
 	 * Unless set to false, clicking on the darkened area outside of the dialog will cancel the dialog.
 	 */
 	cancel_on_click_outside?: boolean
+	width?: number
 }
 
 declare class Dialog {

--- a/types/display_mode.d.ts
+++ b/types/display_mode.d.ts
@@ -1,3 +1,7 @@
+declare const DisplayMode: {
+	slots: string[]
+}
+
 interface DisplaySlotOptions {
 	rotation?: ArrayVector3
 	translation?: ArrayVector3

--- a/types/io.d.ts
+++ b/types/io.d.ts
@@ -1,0 +1,2 @@
+
+	declare function autoParseJSON(data: string, feedback?: boolean);

--- a/types/keyframe.d.ts
+++ b/types/keyframe.d.ts
@@ -13,14 +13,14 @@ interface KeyframeOptions {
     channel?: string
     data_points: {}[]
     time: number
-    color: number
-    uniform: boolean
-    interpolation: 'linear' | 'catmullrom' | 'bezier' | 'step' | string
-    bezier_linked: boolean
-    bezier_left_time: ArrayVector3
-    bezier_left_value: ArrayVector3
-    bezier_right_time: ArrayVector3
-    bezier_right_value: ArrayVector3
+    color?: number
+    uniform?: boolean
+    interpolation?: 'linear' | 'catmullrom' | 'bezier' | 'step' | string
+    bezier_linked?: boolean
+    bezier_left_time?: ArrayVector3
+    bezier_left_value?: ArrayVector3
+    bezier_right_time?: ArrayVector3
+    bezier_right_value?: ArrayVector3
 }
 type axisLetter = 'x' | 'y' | 'z'
 
@@ -66,3 +66,5 @@ declare class _Keyframe {
         data_points: object[];
     };
 }
+
+declare function updateKeyframeSelection(): void;

--- a/types/math_util.d.ts
+++ b/types/math_util.d.ts
@@ -1,0 +1,1 @@
+	declare function guid(): string;

--- a/types/mode.d.ts
+++ b/types/mode.d.ts
@@ -31,4 +31,5 @@ declare namespace Modes {
 	const options: {
 		[id: string]: Mode
 	}
+	const selected: Mode;
 }

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -29,7 +29,7 @@ interface PluginOptions {
 	/**
 	 * Set to true if the plugin must finish loading before a project is opened, i. e. because it adds a format
 	 */
-	await_loading?: string
+	await_loading?: boolean
 	/**
 	 * Use the new repository format where plugin, iron, and about are stored in a separate folder
 	 */

--- a/types/preview.d.ts
+++ b/types/preview.d.ts
@@ -20,7 +20,7 @@ type RaycastResult = {
     intersects?: object[]
     face?: string
     vertex: any
-    keyframe: Keyframe
+    keyframe: _Keyframe
 }
 
 /**

--- a/types/project.d.ts
+++ b/types/project.d.ts
@@ -15,6 +15,7 @@ declare class ModelProject {
 	uuid: UUID
 	selected: boolean
 	model_identifier: string
+	parent: string
 	/**
 	 * When set to true, the project tab can no longer be selected or unselected
 	 */
@@ -56,7 +57,7 @@ declare class ModelProject {
 	textures: Texture[]
 	selected_texture: Texture | null;
 	outliner: OutlinerNode[]
-	animations: Animation[]
+	animations: _Animation[]
 	timeline_animators: []
 	display_settings: {
 		[slot: string]: {
@@ -64,8 +65,12 @@ declare class ModelProject {
 			rotation: [number, number, number]
 			scale: [number, number, number]
 			mirror: [boolean, boolean, boolean]
+			export(): void;
 		}
 	};
+	ambientocclusion: boolean;
+	front_gui_light: boolean;
+	overrides: any;
 
 	get model_3d(): THREE.Object3D;
     get materials(): {

--- a/types/timeline.d.ts
+++ b/types/timeline.d.ts
@@ -1,6 +1,6 @@
 declare namespace Timeline {
     const animators: GeneralAnimator[]
-    const selected: Keyframe[]
+    const selected: _Keyframe[]
     const playing_sounds: any[]
     let playback_speed: number
     /**
@@ -58,7 +58,7 @@ declare namespace Timeline {
      */
     function pause(): void
 
-    let keyframes: Keyframe[]
+    let keyframes: _Keyframe[]
     let menu: Menu
     function showMenu(event: Event): void
 

--- a/types/undo.d.ts
+++ b/types/undo.d.ts
@@ -20,9 +20,9 @@ interface UndoAspects {
     selected_texture?: boolean
     settings?: {}
     uv_mode?: boolean
-    animations?: Animation[]
+    animations?: _Animation[]
     animation_controllers?: AnimationController[]
-    keyframes?: Keyframe[]
+    keyframes?: _Keyframe[]
     display_slots?: string[]
     exploded_view?: boolean
 }
@@ -85,7 +85,7 @@ declare class UndoSystem {
      * Add keyframes to the current edit that were indirectly removed by moving other keyframes to their position
      * @param keyframes 
      */
-    addKeyframeCasualties(keyframes: Keyframe[]): void;
+    addKeyframeCasualties(keyframes: _Keyframe[]): void;
     /**
      * Undoes the latest edit
      */


### PR DESCRIPTION
I have been working on a [port of the animation_utils plugin to TypeScript](https://github.com/JannisX11/blockbench-plugins/compare/master...fadookie:geckolib-plugin:geckolib-typescript?expand=1) and encountered several errors and omissions in the type declarations that were causing compiler errors. I have checked my usage against the blockbench source code and believe it to be correct, and the errors were in the types and not my code. This PR fixes these errors.
- References to `Animation` were resolving to the browser [Web Animation API](https://developer.mozilla.org/docs/Web/API/Animation) type, these have been fixed to point to the blockbench type.
- References to `Keyframe` were resolving to the [Web Animations API Keyframe](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API/Keyframe_Formats) type, these have been fixed to point to the blockbench type.
- Several types were missing methods, properties, and arguments. These have been added.
- Some types were overzealous in requiring properties or arguments that are de-facto optional, these have been made optional.
- Several global objects and properties were missing, these have been added.

Thanks for taking a look!