### PR TITLE
fix: Vue types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blockbench-types",
-	"version": "4.9.0",
+	"version": "4.10.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blockbench-types",
-			"version": "4.9.0",
+			"version": "4.10.0",
 			"dependencies": {
 				"@babel/types": "^7.20.7",
 				"@types/dompurify": "^3.0.5",
@@ -19,7 +19,7 @@
 				"prismjs": "^1.29.0",
 				"tinycolor2": "^1.6.0",
 				"typescript": "^4.9.5",
-				"vue": "^3.2.45",
+				"vue": "2.7.14",
 				"wintersky": "^1.3.0"
 			},
 			"devDependencies": {
@@ -87,11 +87,6 @@
 			"optionalDependencies": {
 				"global-agent": "^3.0.0"
 			}
-		},
-		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.15",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
 		},
 		"node_modules/@sindresorhus/is": {
 			"version": "4.6.0",
@@ -205,95 +200,15 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@vue/compiler-core": {
-			"version": "3.4.26",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.26.tgz",
-			"integrity": "sha512-N9Vil6Hvw7NaiyFUFBPXrAyETIGlQ8KcFMkyk6hW1Cl6NvoqvP+Y8p1Eqvx+UdqsnrnI9+HMUEJegzia3mhXmQ==",
-			"dependencies": {
-				"@babel/parser": "^7.24.4",
-				"@vue/shared": "3.4.26",
-				"entities": "^4.5.0",
-				"estree-walker": "^2.0.2",
-				"source-map-js": "^1.2.0"
-			}
-		},
-		"node_modules/@vue/compiler-dom": {
-			"version": "3.4.26",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.26.tgz",
-			"integrity": "sha512-4CWbR5vR9fMg23YqFOhr6t6WB1Fjt62d6xdFPyj8pxrYub7d+OgZaObMsoxaF9yBUHPMiPFK303v61PwAuGvZA==",
-			"dependencies": {
-				"@vue/compiler-core": "3.4.26",
-				"@vue/shared": "3.4.26"
-			}
-		},
 		"node_modules/@vue/compiler-sfc": {
-			"version": "3.4.26",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.26.tgz",
-			"integrity": "sha512-It1dp+FAOCgluYSVYlDn5DtZBxk1NCiJJfu2mlQqa/b+k8GL6NG/3/zRbJnHdhV2VhxFghaDq5L4K+1dakW6cw==",
+			"version": "2.7.14",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
+			"integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
 			"dependencies": {
-				"@babel/parser": "^7.24.4",
-				"@vue/compiler-core": "3.4.26",
-				"@vue/compiler-dom": "3.4.26",
-				"@vue/compiler-ssr": "3.4.26",
-				"@vue/shared": "3.4.26",
-				"estree-walker": "^2.0.2",
-				"magic-string": "^0.30.10",
-				"postcss": "^8.4.38",
-				"source-map-js": "^1.2.0"
+				"@babel/parser": "^7.18.4",
+				"postcss": "^8.4.14",
+				"source-map": "^0.6.1"
 			}
-		},
-		"node_modules/@vue/compiler-ssr": {
-			"version": "3.4.26",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.26.tgz",
-			"integrity": "sha512-FNwLfk7LlEPRY/g+nw2VqiDKcnDTVdCfBREekF8X74cPLiWHUX6oldktf/Vx28yh4STNy7t+/yuLoMBBF7YDiQ==",
-			"dependencies": {
-				"@vue/compiler-dom": "3.4.26",
-				"@vue/shared": "3.4.26"
-			}
-		},
-		"node_modules/@vue/reactivity": {
-			"version": "3.4.26",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.26.tgz",
-			"integrity": "sha512-E/ynEAu/pw0yotJeLdvZEsp5Olmxt+9/WqzvKff0gE67tw73gmbx6tRkiagE/eH0UCubzSlGRebCbidB1CpqZQ==",
-			"dependencies": {
-				"@vue/shared": "3.4.26"
-			}
-		},
-		"node_modules/@vue/runtime-core": {
-			"version": "3.4.26",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.26.tgz",
-			"integrity": "sha512-AFJDLpZvhT4ujUgZSIL9pdNcO23qVFh7zWCsNdGQBw8ecLNxOOnPcK9wTTIYCmBJnuPHpukOwo62a2PPivihqw==",
-			"dependencies": {
-				"@vue/reactivity": "3.4.26",
-				"@vue/shared": "3.4.26"
-			}
-		},
-		"node_modules/@vue/runtime-dom": {
-			"version": "3.4.26",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.26.tgz",
-			"integrity": "sha512-UftYA2hUXR2UOZD/Fc3IndZuCOOJgFxJsWOxDkhfVcwLbsfh2CdXE2tG4jWxBZuDAs9J9PzRTUFt1PgydEtItw==",
-			"dependencies": {
-				"@vue/runtime-core": "3.4.26",
-				"@vue/shared": "3.4.26",
-				"csstype": "^3.1.3"
-			}
-		},
-		"node_modules/@vue/server-renderer": {
-			"version": "3.4.26",
-			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.26.tgz",
-			"integrity": "sha512-xoGAqSjYDPGAeRWxeoYwqJFD/gw7mpgzOvSxEmjWaFO2rE6qpbD1PC172YRpvKhrihkyHJkNDADFXTfCyVGhKw==",
-			"dependencies": {
-				"@vue/compiler-ssr": "3.4.26",
-				"@vue/shared": "3.4.26"
-			},
-			"peerDependencies": {
-				"vue": "3.4.26"
-			}
-		},
-		"node_modules/@vue/shared": {
-			"version": "3.4.26",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.26.tgz",
-			"integrity": "sha512-Fg4zwR0GNnjzodMt3KRy2AWGMKQXByl56+4HjN87soxLNU9P5xcJkstAlIeEF3cU6UYOzmJl1tV0dVPGIljCnQ=="
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -492,17 +407,6 @@
 				"once": "^1.4.0"
 			}
 		},
-		"node_modules/entities": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
 		"node_modules/env-paths": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -549,11 +453,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/estree-walker": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
 		},
 		"node_modules/extract-zip": {
 			"version": "2.0.1",
@@ -850,14 +749,6 @@
 			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
 			"dev": true
 		},
-		"node_modules/magic-string": {
-			"version": "0.30.10",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-			"integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.15"
-			}
-		},
 		"node_modules/marked": {
 			"version": "4.2.12",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
@@ -971,9 +862,9 @@
 			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
 		},
 		"node_modules/picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+			"integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
 		},
 		"node_modules/postcss": {
 			"version": "8.4.38",
@@ -1126,6 +1017,14 @@
 				"vscode-textmate": "^8.0.0"
 			}
 		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
@@ -1240,23 +1139,13 @@
 			"dev": true
 		},
 		"node_modules/vue": {
-			"version": "3.4.26",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-3.4.26.tgz",
-			"integrity": "sha512-bUIq/p+VB+0xrJubaemrfhk1/FiW9iX+pDV+62I/XJ6EkspAO9/DXEjbDFoe8pIfOZBqfk45i9BMc41ptP/uRg==",
+			"version": "2.7.14",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
+			"integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
+			"deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.",
 			"dependencies": {
-				"@vue/compiler-dom": "3.4.26",
-				"@vue/compiler-sfc": "3.4.26",
-				"@vue/runtime-dom": "3.4.26",
-				"@vue/server-renderer": "3.4.26",
-				"@vue/shared": "3.4.26"
-			},
-			"peerDependencies": {
-				"typescript": "*"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
+				"@vue/compiler-sfc": "2.7.14",
+				"csstype": "^3.1.0"
 			}
 		},
 		"node_modules/wintersky": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"prismjs": "^1.29.0",
 		"tinycolor2": "^1.6.0",
 		"typescript": "^4.9.5",
-		"vue": "^3.2.45",
+		"vue": "2.7.14",
 		"wintersky": "^1.3.0"
 	},
 	"devDependencies": {

--- a/types/blockbench.d.ts
+++ b/types/blockbench.d.ts
@@ -50,7 +50,6 @@
 /// <reference types="./math_util" />
 /// <reference types="./canvas_frame" />
 /// <reference types="./io" />
-/// <reference types="./vue" />
 
 /**
  * The resource identifier group, used to allow the file dialog (open and save) to remember where it was last used

--- a/types/panel.d.ts
+++ b/types/panel.d.ts
@@ -1,5 +1,5 @@
 /// <reference path="./blockbench.d.ts"/>
-/// <reference path="./vue.d.ts"/>
+
 type PanelSlot = 'left_bar' | 'right_bar' | 'top' | 'bottom' | 'float'
 
 interface PanelOptions {

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -1,8 +1,0 @@
-declare namespace Vue {
-	type Component = any
-}
-declare class Vue {
-	_data: any
-	$options: any
-	extend(options: any): Vue.Component
-}

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -4,4 +4,5 @@ declare namespace Vue {
 declare class Vue {
 	_data: any
 	$options: any
+	extend(options: any): Vue.Component
 }


### PR DESCRIPTION
Updating this package to 4.10.0 broke types for `Vue.extend` in plugins. Redeclaring the Vue namespace in `vue.d.ts` would be for Vue 3 usage, but Blockbench is using Vue 2.7.14.

This PR changes the Vue version in `package.json` to match the version used in Blockbench 4.10.1. It also removed the `vue.d.ts` file and its references.