### PR TITLE
Minor type changes

### DIFF
--- a/types/cube.d.ts
+++ b/types/cube.d.ts
@@ -18,7 +18,7 @@ interface ICubeOptions {
 	 * UV position for box UV mode
 	 */
 	uv_offset: ArrayVector2
-	faces: Partial<Record<CardinalDirection, CubeFaceOptions>>
+	faces: Record<CardinalDirection, CubeFaceOptions>
 }
 
 declare class Cube extends OutlinerElement {

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -132,7 +132,7 @@ declare global {
 
 		V3_set(x: number, y: number, z: number): this
 		V3_set(values: ArrayVector3): this
-		//V3_set(value: THREE.Vector3): this
+		V3_set(value: THREE.Vector3): this
 		V3_add(x: number, y: number, z: number): this
 		V3_add(values: ArrayVector3): this
 		V3_add(value: THREE.Vector3): this


### PR DESCRIPTION
- All of the options in CubeFaceOptions (and FaceOptions) are already optional, so including a `Partial` changes nothing.
- V3_set is a valid overload, and should be included in the types