### PR TITLE
Misc type fixes and enhancements I've accumulated

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"editor.formatOnSave": true
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blockbench-types",
-	"version": "4.12.0",
+	"version": "4.12.2",
 	"description": "Blockbench typescript types",
 	"main": "",
 	"types": "types/index.d.ts",

--- a/scripts/generate_docs.js
+++ b/scripts/generate_docs.js
@@ -3,14 +3,14 @@ const fs = require('fs')
 const PathModule = require('path')
 
 function getArg(key) {
-	let index = process.argv.indexOf('--'+key);
+	let index = process.argv.indexOf('--' + key)
 	console.log(index)
 	if (index > 1) {
-		return process.argv[index+1];
+		return process.argv[index + 1]
 	}
 }
 
-const out_path = getArg('out') || '../generated/';
+const out_path = getArg('out') || '../generated/'
 console.log(out_path)
 
 async function main() {

--- a/types/action.d.ts
+++ b/types/action.d.ts
@@ -71,7 +71,7 @@ declare class Keybind {
 	/**
 	 * Get the name of the bound key
 	 */
-	getCode(key: string): string
+	getCode(key?: string): string
 	/**
 	 * Check if a key is assigned
 	 */

--- a/types/action.d.ts
+++ b/types/action.d.ts
@@ -2,596 +2,601 @@
  * Registry of all toolbar items, such as actions, tools, etc.
  */
 /// <reference path="./blockbench.d.ts"/>
-declare const BarItems: {
-	[id: string]: BarItem
-}
 
-declare interface KeybindKeys {
-	/**
-	 * Main key, can be a numeric keycode or a lower case character
-	 */
-	key: number | string
-	ctrl?: boolean
-	shift?: boolean
-	alt?: boolean
-	meta?: boolean
-}
-type VariationModifier =
-	| 'always'
-	| 'ctrl'
-	| 'shift'
-	| 'alt'
-	| 'meta'
-	| 'unless_ctrl'
-	| 'unless_shift'
-	| 'unless_alt'
-type ModifierKey = 'ctrl' | 'shift' | 'alt' | 'meta'
-/**
- * A customizable keybind
- */
-declare class Keybind {
-	/**
-	 * Create a keybind
-	 * @param {object} keys Set up the default keys that need to be pressed
-	 * @param {number|string} keys.key Main key. Check keycode.info to find out the numeric value, or simply use letters for letter keys
-	 * @param {boolean} keys.ctrl Control key. On MacOS this automatically works for Cmd
-	 * @param {boolean} keys.shift Shift key
-	 * @param {boolean} keys.alt Alt key
-	 * @param {boolean} keys.meta Meta key
-	 */
-	constructor(keys: KeybindKeys, variations?: Record<string, VariationModifier>)
-	key: number
-	ctrl?: boolean
-	shift?: boolean
-	alt?: boolean
-	variations?: {
-		[key: string]: { name: string; description?: string }
+import tinycolor from 'tinycolor2'
+
+declare global {
+	const BarItems: {
+		[id: string]: BarItem
 	}
-	set(keys: KeybindKeys): this
-	/**
-	 * Unassign the assigned key
-	 */
-	clear(): this
-	/**
-	 * Save any changes to local storage
-	 * @param save Save all keybinding changes to local storage. Set to fales if updating multiple at once
-	 */
-	save(save?: false): this
-	/**
-	 * Assign an action to the keybind
-	 * @param id ID of the action
-	 * @param sub_id sub keybind ID
-	 */
-	setAction(id: string, sub_id?: string): this | undefined
-	/**
-	 * Get display text showing the keybind
-	 * @param formatted If true, the return string will include HTML formatting
-	 */
-	getText(formatted?: boolean): string
-	/**
-	 * Get the name of the bound key
-	 */
-	getCode(key?: string): string
-	/**
-	 * Check if a key is assigned
-	 */
-	hasKey(): boolean
-	/**
-	 * Test if the keybind would be triggered by the event
-	 */
-	isTriggered(event: Event): boolean
-	/**
-	 * Test which variation would be triggered by the event. Returns the ID of the variation if triggered
-	 * @param event The event to test
-	 */
-	additionalModifierTriggered(event: Event): string | undefined
-	/**
-	 * Test if a variation would be triggered by the event
-	 * @param event The event to test
-	 * @param variation The variation to test againts
-	 */
-	additionalModifierTriggered(event: Event, variation: string): boolean
-	/**
-	 * Open a UI to let the user record a new key combination
-	 */
-	record(): this
-	/**
-	 * Stop recording a new key combination
-	 */
-	stopRecording(): this
-	/**
-	 * Returns the label of the keybinding
-	 */
-	toString(): string
 
-	/**
-	 * Load an included keymap by ID
-	 * @param id
-	 * @param from_start_screen
-	 */
-	static loadKeymap(id: string, from_start_screen?: boolean): void | true
-	/**
-	 * Check if two KeybindItems are mutually exclusive, so only one can be available at the time. This is only the case if they each have a ConditionResolvable that is structured to support this
-	 */
-	static no_overlap(k1: KeybindItem, k2: KeybindItem): boolean
-}
-interface KeybindItemOptions {
-	keybind?: Keybind
-	variations?: {
-		[key: string]: { name: string; description?: string }
+	interface KeybindKeys {
+		/**
+		 * Main key, can be a numeric keycode or a lower case character
+		 */
+		key: number | string
+		ctrl?: boolean
+		shift?: boolean
+		alt?: boolean
+		meta?: boolean
 	}
-}
-declare class KeybindItem extends Deletable {
-	constructor(id: string, options: KeybindItemOptions)
-	keybind: Keybind
-	variations?: {
-		[key: string]: { name: string; description?: string }
-	}
-}
-
-declare class MenuSeparator {
-	constructor(id?: string, label?: string)
-}
-type ActionEventName =
-	| 'delete'
-	| 'use'
-	| 'used'
-	| 'trigger'
-	| 'get_node'
-	| 'select'
-	| 'change'
-	| 'changed'
-	| 'update'
-	| 'open'
-interface BarItemOptions extends KeybindItemOptions {
-	name?: string
-	description?: string
-	icon?: string
-	condition?: ConditionResolvable
-	category?: string
-	keybind?: Keybind
-}
-/**
- * Anything that can go into a toolbar, including actions, tools, toggles, widgets etc.
- */
-declare class BarItem extends KeybindItem {
-	constructor(id: string, options: BarItemOptions)
-	id: string
-	node: HTMLElement
-	nodes: HTMLElement[]
-	conditionMet(): boolean
+	type VariationModifier =
+		| 'always'
+		| 'ctrl'
+		| 'shift'
+		| 'alt'
+		| 'meta'
+		| 'unless_ctrl'
+		| 'unless_shift'
+		| 'unless_alt'
+	type ModifierKey = 'ctrl' | 'shift' | 'alt' | 'meta'
 	/**
-	 * Adds a label to the HTML element of the bar item
-	 * @param in_bar Set to true to generate an in-bar label, as opposed to a regular on-hover label
-	 * @param action Provide the action to generate the label. This defaults to self and is only needed in special cases
+	 * A customizable keybind
 	 */
-	addLabel(in_bar?: boolean, action?: any): void
-	/**
-	 * Gets a copy of the elements HTML node that is not yet in use.
-	 */
-	getNode(): HTMLElement
-	/**
-	 * Appends the bar item to a HTML element
-	 */
-	toElement(destination: HTMLElement): this
-	pushToolbar(bar: any): void
-
-	/**
-	 * Adds an event listener to the item
-	 * @param event_name The event type to listen for
-	 * @param callback
-	 */
-	on(event_name: ActionEventName, callback: (data: object) => void): void
-	/**
-	 * Adds a single-use event listener to the item
-	 * @param event_name The event type to listen for
-	 * @param callback
-	 */
-	once(event_name: ActionEventName, callback: (data: object) => void): void
-	/**
-	 * Removes an event listener from the item
-	 * @param event_name
-	 * @param callback
-	 */
-	removeListener(event_name: ActionEventName, callback: (data: object) => void): void
-	constructor(id: string, options: BarItemOptions)
-	conditionMet(): boolean
-	/**
-	 * Adds a label to the HTML element of the bar item
-	 * @param in_bar Set to true to generate an in-bar label, as opposed to a regular on-hover label
-	 * @param action Provide the action to generate the label. This defaults to self and is only needed in special cases
-	 */
-	addLabel(in_bar?: boolean, action?: any): void
-	/**
-	 * Gets a copy of the elements HTML node that is not yet in use.
-	 */
-	getNode(): HTMLElement
-	/**
-	 * Appends the bar item to a HTML element
-	 */
-	toElement(destination: HTMLElement): this
-	pushToolbar(bar: any): void
-
-	dispatchEvent<T = EventName>(event: T, ...args: any[]): void
-}
-
-interface ActionOptions extends BarItemOptions {
-	/**
-	 * Function to run when user uses the action successfully
-	 */
-	click(event?: Event): void
-	/**
-	 * Icon color. Can be a CSS color string, or an axis letter to use an axis color.
-	 */
-	color?: string
-	/**
-	 * ID of a setting that the action is slinked to
-	 */
-	linked_setting?: string
-	children?: any[]
-	/**
-	 * Show the full label in toolbars
-	 */
-	label?: boolean
-	/**
-	 * Provide a menu that belongs to the action, and gets displayed as a small arrow next to it in toolbars.
-	 */
-	side_menu?: Menu
-	/**
-	 * Provide a window with additional configutation related to the action
-	 */
-	tool_config?: ToolConfig
-}
-/**
- * Actions can be triggered to run something, they can be added to menus, toolbars, assigned a keybinding, or run via Action Control
- */
-declare class Action extends BarItem {
-	constructor(id: string, options: ActionOptions)
-	nodes: HTMLElement[]
-	/**
-	 * Provide a menu that belongs to the action, and gets displayed as a small arrow next to it in toolbars.
-	 */
-	side_menu?: Menu | ToolConfig
-	/**
-	 * Provide a window with additional configutation related to the action
-	 */
-	tool_config?: ToolConfig
-	click: ActionOptions['click']
-
-	condition?(): boolean
-	/**
-	 * Trigger to run or select the action. This is the equivalent of clicking or using a keybind to trigger it. Also checks if the condition is met.
-	 */
-	trigger(event?: Event): boolean
-	updateKeybindingLabel(): this
-	/** Change the icon of the action */
-	setIcon(icon: IconString): void
-	toggleLinkedSetting(change: any): void
-}
-interface ToggleOptions extends ActionOptions {
-	/**
-	 * Default value of the toggle
-	 */
-	default?: boolean
-	/**
-	 * Method that gets called when the user changes the value of the toggle
-	 */
-	onChange?(value: boolean): void
-}
-/**
- * A toggle is a type of action that can be on or off. The state is not persistent between restarts by default.
- */
-declare class Toggle extends Action {
-	value: boolean
-	constructor(id: string, options: ToggleOptions)
-	/**
-	 * Updates the state of the toggle in the UI
-	 */
-	updateEnabledState(): void
-	set(value: boolean): this
-	setIcon(icon: IconString): void
-}
-
-type RGBAColor = { r: number; g: number; b: number; a: number }
-type ViewMode = 'textured' | 'solid' | 'wireframe' | 'uv' | 'normal'
-type PaintContext = {
-	/**
-	 * Brush color, set by the Blockbench color panel
-	 */
-	color: string
-	/**
-	 * Opacity, as set by the Opacity slider
-	 */
-	opacity: number
-	/**
-	 * 2D Canvas context of the texture that is being edited
-	 */
-	ctx: CanvasRenderingContext2D
-	/**X Coordinate of the position of the brush stroke */
-	x: number
-	/**Y Coordinate of the position of the brush stroke */
-	y: number
-	/**
-	 * Brush size, as set by the Brush Size slider
-	 */
-	size: number
-	/**
-	 * Brush softness, as set by the Brush Softness slider
-	 */
-	softness: number
-	/**
-	 * Blockbench texture that is being edited
-	 */
-	texture: Texture
-	/**
-	 * Javascript pointer event that the brush stroke originated from
-	 */
-	event: PointerEvent
-}
-interface BrushOptions {
-	/**
-	 * Enable the input for blend modes when this tool is selected
-	 */
-	blend_modes: boolean
-	/**
-	 * Enable the input for shapes when this tool is selected
-	 */
-	shapes: boolean
-	/**
-	 * Enable the input for brush size when this tool is selected
-	 */
-	size: boolean
-	/**
-	 * Enable the input for softness when this tool is selected
-	 */
-	softness: boolean
-	/**
-	 * Enable the input for opacity when this tool is selected
-	 */
-	opacity: boolean
-	/**
-	 * When the brush size is an even number, offset the snapping by half a pixel so that even size brush strokes can be correctly centered
-	 */
-	offset_even_radius: boolean
-	/**
-	 * Set whether the brush coordinates get floored to snap to the nearest pixel.
-	 */
-	floor_coordinates: boolean | (() => boolean)
-	/**
-	 * Function that runs per pixel when the brush is used. Mutually exclusive with draw().
-	 * @param pixel_x Local X coordinate relative to the brush center
-	 * @param pixel_y Local Y coordinate relative to the brush center
-	 * @param pixel_color Current color of the pixel on the texture
-	 * @param local_opacity Local opacity of the current pixel on the brush, between 0 and 1. Opacity falls of to the sides of the brush if the brush is set to smooth. Opacity from the Opacity slider is not factored in yet.
-	 * @param PaintContext Additional context to the paint stroke
-	 */
-	changePixel(
-		pixel_x: number,
-		pixel_y: number,
-		pixel_color: RGBAColor,
-		local_opacity: number,
-		PaintContext: PaintContext
-	): RGBAColor
-	/**
-	 * Function that runs when a new brush stroke starts. Return false to cancel the brush stroke
-	 * @param context
-	 */
-	onStrokeStart(context: {
-		texture: Texture
-		x: number
-		y: number
-		uv?: any
-		event: PointerEvent
-		raycast_data: RaycastResult
-	}): boolean
-	/**
-	 * Function that runs when a new brush stroke starts. Return false to cancel the brush stroke
-	 * @param context
-	 */
-	onStrokeMove(context: {
-		texture: Texture
-		x: number
-		y: number
-		uv?: any
-		event: PointerEvent
-		raycast_data: RaycastResult
-	}): boolean
-	/**
-	 * Function that runs when a new brush stroke starts.
-	 * @param context
-	 */
-	onStrokeEnd(context: {
-		texture: Texture
-		x: number
-		y: number
-		uv?: any
-		raycast_data: RaycastResult
-	}): void
-	/**
-	 * Alternative way to create a custom brush, mutually exclusive with the changePixel() function. Draw runs once every time the brush starts or moves, and also along the bath on lines.
-	 * @param context
-	 */
-	draw(context: {
-		ctx: CanvasRenderingContext2D
-		x: number
-		y: number
-		size: number
-		softness: number
-		texture: Texture
-		event: PointerEvent
-	}): void
-}
-interface ToolOptions extends ActionOptions {
-	selectFace?: boolean
-	selectElements?: boolean
-	transformerMode?: 'translate' | ''
-	animation_channel?: string
-	toolbar?: string
-	alt_tool?: string
-	modes?: string[]
-	allowed_view_modes?: ViewMode
-	paintTool?: boolean
-	brush?: BrushOptions
-}
-interface WidgetOptions extends BarItemOptions {
-	id?: string
-}
-/**
- * A tool, such as move tool, vertex snap tool, or paint brush
- */
-declare class Tool extends Action {
-	constructor(id: string, options: ToolOptions)
-	animation_channel: string
-	select(): this | undefined
-	trigger(event: Event): boolean
-}
-declare class Widget extends BarItem {
-	constructor(id: string, options: WidgetOptions)
-}
-type NumSliderOptions = WidgetOptions & {
-	settings?: {
-		default?: number
-		min?: number
-		max?: number
-		interval?: number
-		step?: number
-	}
-	change?(value: (n: number) => number): void
-	get?(): number
-}
-declare class NumSlider extends Widget {
-	constructor(id: string, options: NumSliderOptions)
-	startInput(event: Event): void
-	setWidth(width: any): this
-	getInterval(event: Event): number
-	slide(clientX: any, event: Event): void
-	input(): void
-	stopInput(): void
-	arrow(difference: any, event: Event): void
-	trigger(event: Event): boolean
-	setValue(value: number, trim?: any): this
-	change(modify: (n: number) => number): void
-	get(): number
-	update(): void
-}
-declare class BarSlider extends Widget {
-	constructor(id: string, options: NumSliderOptions)
-	change(event: Event): void
-	set(value: number): void
-	get(): number
-}
-interface BarSelectOptions<T> extends WidgetOptions {
-	value?: T
-	options: Record<string, T>
-}
-declare class BarSelect<T> extends Widget {
-	constructor(id: string, options: BarSelectOptions<T>)
-	open(event: Event): void
-	trigger(event: Event): boolean | undefined
-	change(value: T, event: Event): this
-	getNameFor(key: string): string
-	set(key: string): this
-	get(): string
-	value: T
-}
-declare class BarText extends Widget {
-	constructor(
-		id: string,
-		options: WidgetOptions & {
-			text: string
+	class Keybind {
+		/**
+		 * Create a keybind
+		 * @param {object} keys Set up the default keys that need to be pressed
+		 * @param {number|string} keys.key Main key. Check keycode.info to find out the numeric value, or simply use letters for letter keys
+		 * @param {boolean} keys.ctrl Control key. On MacOS this automatically works for Cmd
+		 * @param {boolean} keys.shift Shift key
+		 * @param {boolean} keys.alt Alt key
+		 * @param {boolean} keys.meta Meta key
+		 */
+		constructor(keys: KeybindKeys, variations?: Record<string, VariationModifier>)
+		key: number
+		ctrl?: boolean
+		shift?: boolean
+		alt?: boolean
+		variations?: {
+			[key: string]: { name: string; description?: string }
 		}
-	)
-	set(text: any): this
-	update(): this
-	trigger(event: Event): boolean
-}
-interface ColorPickerOptions extends WidgetOptions {
-	value?: string
-	palette?: boolean
-	onChange?: (color: tinycolor.Instance) => void
-}
-declare class ColorPicker extends Widget {
-	value: tinycolor.Instance
-	jq: JQuery
-	constructor(options: ColorPickerOptions)
-	constructor(id: string, options: ColorPickerOptions)
-	change(color: tinycolor.Instance): void
-	hide(): void
-	confirm(): void
-	set(color: any): this
-	get(): tinycolor.Instance
-}
-interface ToolbarOptions {
-	id: string
-	name?: string
+		set(keys: KeybindKeys): this
+		/**
+		 * Unassign the assigned key
+		 */
+		clear(): this
+		/**
+		 * Save any changes to local storage
+		 * @param save Save all keybinding changes to local storage. Set to fales if updating multiple at once
+		 */
+		save(save?: false): this
+		/**
+		 * Assign an action to the keybind
+		 * @param id ID of the action
+		 * @param sub_id sub keybind ID
+		 */
+		setAction(id: string, sub_id?: string): this | undefined
+		/**
+		 * Get display text showing the keybind
+		 * @param formatted If true, the return string will include HTML formatting
+		 */
+		getText(formatted?: boolean): string
+		/**
+		 * Get the name of the bound key
+		 */
+		getCode(key?: string): string
+		/**
+		 * Check if a key is assigned
+		 */
+		hasKey(): boolean
+		/**
+		 * Test if the keybind would be triggered by the event
+		 */
+		isTriggered(event: Event): boolean
+		/**
+		 * Test which variation would be triggered by the event. Returns the ID of the variation if triggered
+		 * @param event The event to test
+		 */
+		additionalModifierTriggered(event: Event): string | undefined
+		/**
+		 * Test if a variation would be triggered by the event
+		 * @param event The event to test
+		 * @param variation The variation to test againts
+		 */
+		additionalModifierTriggered(event: Event, variation: string): boolean
+		/**
+		 * Open a UI to let the user record a new key combination
+		 */
+		record(): this
+		/**
+		 * Stop recording a new key combination
+		 */
+		stopRecording(): this
+		/**
+		 * Returns the label of the keybinding
+		 */
+		toString(): string
+
+		/**
+		 * Load an included keymap by ID
+		 * @param id
+		 * @param from_start_screen
+		 */
+		static loadKeymap(id: string, from_start_screen?: boolean): void | true
+		/**
+		 * Check if two KeybindItems are mutually exclusive, so only one can be available at the time. This is only the case if they each have a ConditionResolvable that is structured to support this
+		 */
+		static no_overlap(k1: KeybindItem, k2: KeybindItem): boolean
+	}
+	interface KeybindItemOptions {
+		keybind?: Keybind
+		variations?: {
+			[key: string]: { name: string; description?: string }
+		}
+	}
+	class KeybindItem extends Deletable {
+		constructor(id: string, options: KeybindItemOptions)
+		keybind: Keybind
+		variations?: {
+			[key: string]: { name: string; description?: string }
+		}
+	}
+
+	class MenuSeparator {
+		constructor(id?: string, label?: string)
+	}
+	type ActionEventName =
+		| 'delete'
+		| 'use'
+		| 'used'
+		| 'trigger'
+		| 'get_node'
+		| 'select'
+		| 'change'
+		| 'changed'
+		| 'update'
+		| 'open'
+	interface BarItemOptions extends KeybindItemOptions {
+		name?: string
+		description?: string
+		icon?: string
+		condition?: ConditionResolvable
+		category?: string
+		keybind?: Keybind
+	}
 	/**
-	 * If true, the toolbar will display a label abovee
+	 * Anything that can go into a toolbar, including actions, tools, toggles, widgets etc.
 	 */
-	label?: boolean
-	condition?: ConditionResolvable
+	class BarItem extends KeybindItem {
+		constructor(id: string, options: BarItemOptions)
+		id: string
+		node: HTMLElement
+		nodes: HTMLElement[]
+		conditionMet(): boolean
+		/**
+		 * Adds a label to the HTML element of the bar item
+		 * @param in_bar Set to true to generate an in-bar label, as opposed to a regular on-hover label
+		 * @param action Provide the action to generate the label. This defaults to self and is only needed in special cases
+		 */
+		addLabel(in_bar?: boolean, action?: any): void
+		/**
+		 * Gets a copy of the elements HTML node that is not yet in use.
+		 */
+		getNode(): HTMLElement
+		/**
+		 * Appends the bar item to a HTML element
+		 */
+		toElement(destination: HTMLElement): this
+		pushToolbar(bar: any): void
+
+		/**
+		 * Adds an event listener to the item
+		 * @param event_name The event type to listen for
+		 * @param callback
+		 */
+		on(event_name: ActionEventName, callback: (data: object) => void): void
+		/**
+		 * Adds a single-use event listener to the item
+		 * @param event_name The event type to listen for
+		 * @param callback
+		 */
+		once(event_name: ActionEventName, callback: (data: object) => void): void
+		/**
+		 * Removes an event listener from the item
+		 * @param event_name
+		 * @param callback
+		 */
+		removeListener(event_name: ActionEventName, callback: (data: object) => void): void
+		constructor(id: string, options: BarItemOptions)
+		conditionMet(): boolean
+		/**
+		 * Adds a label to the HTML element of the bar item
+		 * @param in_bar Set to true to generate an in-bar label, as opposed to a regular on-hover label
+		 * @param action Provide the action to generate the label. This defaults to self and is only needed in special cases
+		 */
+		addLabel(in_bar?: boolean, action?: any): void
+		/**
+		 * Gets a copy of the elements HTML node that is not yet in use.
+		 */
+		getNode(): HTMLElement
+		/**
+		 * Appends the bar item to a HTML element
+		 */
+		toElement(destination: HTMLElement): this
+		pushToolbar(bar: any): void
+
+		dispatchEvent<T = EventName>(event: T, ...args: any[]): void
+	}
+
+	interface ActionOptions extends BarItemOptions {
+		/**
+		 * Function to run when user uses the action successfully
+		 */
+		click(event?: Event): void
+		/**
+		 * Icon color. Can be a CSS color string, or an axis letter to use an axis color.
+		 */
+		color?: string
+		/**
+		 * ID of a setting that the action is slinked to
+		 */
+		linked_setting?: string
+		children?: any[]
+		/**
+		 * Show the full label in toolbars
+		 */
+		label?: boolean
+		/**
+		 * Provide a menu that belongs to the action, and gets displayed as a small arrow next to it in toolbars.
+		 */
+		side_menu?: Menu
+		/**
+		 * Provide a window with additional configutation related to the action
+		 */
+		tool_config?: ToolConfig
+	}
 	/**
-	 * If true, the toolbar will only take as much width as needed
+	 * Actions can be triggered to run something, they can be added to menus, toolbars, assigned a keybinding, or run via Action Control
 	 */
-	narrow?: boolean
-	vertical?: boolean
+	class Action extends BarItem {
+		constructor(id: string, options: ActionOptions)
+		nodes: HTMLElement[]
+		/**
+		 * Provide a menu that belongs to the action, and gets displayed as a small arrow next to it in toolbars.
+		 */
+		side_menu?: Menu | ToolConfig
+		/**
+		 * Provide a window with additional configutation related to the action
+		 */
+		tool_config?: ToolConfig
+		click: ActionOptions['click']
+
+		condition?(): boolean
+		/**
+		 * Trigger to run or select the action. This is the equivalent of clicking or using a keybind to trigger it. Also checks if the condition is met.
+		 */
+		trigger(event?: Event): boolean
+		updateKeybindingLabel(): this
+		/** Change the icon of the action */
+		setIcon(icon: IconString): void
+		toggleLinkedSetting(change: any): void
+	}
+	interface ToggleOptions extends ActionOptions {
+		/**
+		 * Default value of the toggle
+		 */
+		default?: boolean
+		/**
+		 * Method that gets called when the user changes the value of the toggle
+		 */
+		onChange?(value: boolean): void
+	}
 	/**
-	 * Default content of the toolbar. Separators are available, where _ = separator, + = spaces, # = line break
+	 * A toggle is a type of action that can be on or off. The state is not persistent between restarts by default.
 	 */
-	children: ('_' | '+' | '#' | string | BarItem)[]
+	class Toggle extends Action {
+		value: boolean
+		constructor(id: string, options: ToggleOptions)
+		/**
+		 * Updates the state of the toggle in the UI
+		 */
+		updateEnabledState(): void
+		set(value: boolean): this
+		setIcon(icon: IconString): void
+	}
+
+	type RGBAColor = { r: number; g: number; b: number; a: number }
+	type ViewMode = 'textured' | 'solid' | 'wireframe' | 'uv' | 'normal'
+	type PaintContext = {
+		/**
+		 * Brush color, set by the Blockbench color panel
+		 */
+		color: string
+		/**
+		 * Opacity, as set by the Opacity slider
+		 */
+		opacity: number
+		/**
+		 * 2D Canvas context of the texture that is being edited
+		 */
+		ctx: CanvasRenderingContext2D
+		/**X Coordinate of the position of the brush stroke */
+		x: number
+		/**Y Coordinate of the position of the brush stroke */
+		y: number
+		/**
+		 * Brush size, as set by the Brush Size slider
+		 */
+		size: number
+		/**
+		 * Brush softness, as set by the Brush Softness slider
+		 */
+		softness: number
+		/**
+		 * Blockbench texture that is being edited
+		 */
+		texture: Texture
+		/**
+		 * Javascript pointer event that the brush stroke originated from
+		 */
+		event: PointerEvent
+	}
+	interface BrushOptions {
+		/**
+		 * Enable the input for blend modes when this tool is selected
+		 */
+		blend_modes: boolean
+		/**
+		 * Enable the input for shapes when this tool is selected
+		 */
+		shapes: boolean
+		/**
+		 * Enable the input for brush size when this tool is selected
+		 */
+		size: boolean
+		/**
+		 * Enable the input for softness when this tool is selected
+		 */
+		softness: boolean
+		/**
+		 * Enable the input for opacity when this tool is selected
+		 */
+		opacity: boolean
+		/**
+		 * When the brush size is an even number, offset the snapping by half a pixel so that even size brush strokes can be correctly centered
+		 */
+		offset_even_radius: boolean
+		/**
+		 * Set whether the brush coordinates get floored to snap to the nearest pixel.
+		 */
+		floor_coordinates: boolean | (() => boolean)
+		/**
+		 * Function that runs per pixel when the brush is used. Mutually exclusive with draw().
+		 * @param pixel_x Local X coordinate relative to the brush center
+		 * @param pixel_y Local Y coordinate relative to the brush center
+		 * @param pixel_color Current color of the pixel on the texture
+		 * @param local_opacity Local opacity of the current pixel on the brush, between 0 and 1. Opacity falls of to the sides of the brush if the brush is set to smooth. Opacity from the Opacity slider is not factored in yet.
+		 * @param PaintContext Additional context to the paint stroke
+		 */
+		changePixel(
+			pixel_x: number,
+			pixel_y: number,
+			pixel_color: RGBAColor,
+			local_opacity: number,
+			PaintContext: PaintContext
+		): RGBAColor
+		/**
+		 * Function that runs when a new brush stroke starts. Return false to cancel the brush stroke
+		 * @param context
+		 */
+		onStrokeStart(context: {
+			texture: Texture
+			x: number
+			y: number
+			uv?: any
+			event: PointerEvent
+			raycast_data: RaycastResult
+		}): boolean
+		/**
+		 * Function that runs when a new brush stroke starts. Return false to cancel the brush stroke
+		 * @param context
+		 */
+		onStrokeMove(context: {
+			texture: Texture
+			x: number
+			y: number
+			uv?: any
+			event: PointerEvent
+			raycast_data: RaycastResult
+		}): boolean
+		/**
+		 * Function that runs when a new brush stroke starts.
+		 * @param context
+		 */
+		onStrokeEnd(context: {
+			texture: Texture
+			x: number
+			y: number
+			uv?: any
+			raycast_data: RaycastResult
+		}): void
+		/**
+		 * Alternative way to create a custom brush, mutually exclusive with the changePixel() function. Draw runs once every time the brush starts or moves, and also along the bath on lines.
+		 * @param context
+		 */
+		draw(context: {
+			ctx: CanvasRenderingContext2D
+			x: number
+			y: number
+			size: number
+			softness: number
+			texture: Texture
+			event: PointerEvent
+		}): void
+	}
+	interface ToolOptions extends ActionOptions {
+		selectFace?: boolean
+		selectElements?: boolean
+		transformerMode?: 'translate' | ''
+		animation_channel?: string
+		toolbar?: string
+		alt_tool?: string
+		modes?: string[]
+		allowed_view_modes?: ViewMode
+		paintTool?: boolean
+		brush?: BrushOptions
+	}
+	interface WidgetOptions extends BarItemOptions {
+		id?: string
+	}
+	/**
+	 * A tool, such as move tool, vertex snap tool, or paint brush
+	 */
+	class Tool extends Action {
+		constructor(id: string, options: ToolOptions)
+		animation_channel: string
+		select(): this | undefined
+		trigger(event: Event): boolean
+	}
+	class Widget extends BarItem {
+		constructor(id: string, options: WidgetOptions)
+	}
+	type NumSliderOptions = WidgetOptions & {
+		settings?: {
+			default?: number
+			min?: number
+			max?: number
+			interval?: number
+			step?: number
+		}
+		change?(value: (n: number) => number): void
+		get?(): number
+	}
+	class NumSlider extends Widget {
+		constructor(id: string, options: NumSliderOptions)
+		startInput(event: Event): void
+		setWidth(width: any): this
+		getInterval(event: Event): number
+		slide(clientX: any, event: Event): void
+		input(): void
+		stopInput(): void
+		arrow(difference: any, event: Event): void
+		trigger(event: Event): boolean
+		setValue(value: number, trim?: any): this
+		change(modify: (n: number) => number): void
+		get(): number
+		update(): void
+	}
+	class BarSlider extends Widget {
+		constructor(id: string, options: NumSliderOptions)
+		change(event: Event): void
+		set(value: number): void
+		get(): number
+	}
+	interface BarSelectOptions<T> extends WidgetOptions {
+		value?: T
+		options: Record<string, T>
+	}
+	class BarSelect<T> extends Widget {
+		constructor(id: string, options: BarSelectOptions<T>)
+		open(event: Event): void
+		trigger(event: Event): boolean | undefined
+		change(value: T, event: Event): this
+		getNameFor(key: string): string
+		set(key: string): this
+		get(): string
+		value: T
+	}
+	class BarText extends Widget {
+		constructor(
+			id: string,
+			options: WidgetOptions & {
+				text: string
+			}
+		)
+		set(text: any): this
+		update(): this
+		trigger(event: Event): boolean
+	}
+	interface ColorPickerOptions extends WidgetOptions {
+		value?: string
+		palette?: boolean
+		onChange?: (color: tinycolor.Instance) => void
+	}
+	class ColorPicker extends Widget {
+		value: tinycolor.Instance
+		jq: JQuery
+		constructor(options: ColorPickerOptions)
+		constructor(id: string, options: ColorPickerOptions)
+		change(color: tinycolor.Instance): void
+		hide(): void
+		confirm(): void
+		set(color: any): this
+		get(): tinycolor.Instance
+	}
+	interface ToolbarOptions {
+		id: string
+		name?: string
+		/**
+		 * If true, the toolbar will display a label abovee
+		 */
+		label?: boolean
+		condition?: ConditionResolvable
+		/**
+		 * If true, the toolbar will only take as much width as needed
+		 */
+		narrow?: boolean
+		vertical?: boolean
+		/**
+		 * Default content of the toolbar. Separators are available, where _ = separator, + = spaces, # = line break
+		 */
+		children: ('_' | '+' | '#' | string | BarItem)[]
+	}
+	class Toolbar {
+		constructor(id: string, data: ToolbarOptions)
+		constructor(data: ToolbarOptions)
+		build(data: any, force: any): this
+		contextmenu(event: Event): void
+		editMenu(): this
+		add(action: any, position?: number): this
+		remove(action: any): this
+		update(): this
+		toPlace(place: any): this
+		save(): this
+		reset(): this
+		condition(): boolean
+	}
+	namespace BARS {
+		const stored: {}
+		const editing_bar: undefined | Toolbar
+		const action_definers: (() => void)[]
+		const condition: any
+		function defineActions(definer: any): void
+		function setupActions(): void
+		function setupToolbars(): void
+		function setupVue(): void
+		function updateConditions(): void
+		function updateToolToolbar(): void
+	}
+	/**
+	 * A dialog-based interface to search and trigger actions and other things
+	 */
+	namespace ActionControl {
+		const open: boolean
+		const type: string
+		const max_length: number
+		function select(): void
+		function hide(): void
+		function confirm(event: Event): void
+		function cancel(): void
+		function trigger(action: any, event: Event): void
+		function click(action: any, event: Event): void
+		function handleKeys(event: Event): boolean
+	}
+	/**
+	 * Stores and handles keybinds
+	 */
+	namespace Keybinds {
+		const actions: BarItem[]
+		const stored: Record<string, { key: number; ctrl: boolean; shift: boolean }>
+		const extra: Record<string, KeybindItem>
+		const structure: any
+		function save(): void
+		function reset(): void
+	}
+	class _ToolToolbar extends Toolbar {
+		selected: Tool
+	}
+	const Toolbox: _ToolToolbar
 }
-declare class Toolbar {
-	constructor(id: string, data: ToolbarOptions)
-	constructor(data: ToolbarOptions)
-	build(data: any, force: any): this
-	contextmenu(event: Event): void
-	editMenu(): this
-	add(action: any, position?: number): this
-	remove(action: any): this
-	update(): this
-	toPlace(place: any): this
-	save(): this
-	reset(): this
-	condition(): boolean
-}
-declare namespace BARS {
-	const stored: {}
-	const editing_bar: undefined | Toolbar
-	const action_definers: (() => void)[]
-	const condition: any
-	function defineActions(definer: any): void
-	function setupActions(): void
-	function setupToolbars(): void
-	function setupVue(): void
-	function updateConditions(): void
-	function updateToolToolbar(): void
-}
-/**
- * A dialog-based interface to search and trigger actions and other things
- */
-declare namespace ActionControl {
-	const open: boolean
-	const type: string
-	const max_length: number
-	function select(): void
-	function hide(): void
-	function confirm(event: Event): void
-	function cancel(): void
-	function trigger(action: any, event: Event): void
-	function click(action: any, event: Event): void
-	function handleKeys(event: Event): boolean
-}
-/**
- * Stores and handles keybinds
- */
-declare namespace Keybinds {
-	const actions: BarItem[]
-	const stored: Record<string, { key: number; ctrl: boolean; shift: boolean }>
-	const extra: Record<string, KeybindItem>
-	const structure: any
-	function save(): void
-	function reset(): void
-}
-declare class _ToolToolbar extends Toolbar {
-	selected: Tool
-}
-declare const Toolbox: _ToolToolbar

--- a/types/action.d.ts
+++ b/types/action.d.ts
@@ -16,7 +16,15 @@ declare interface KeybindKeys {
 	alt?: boolean
 	meta?: boolean
 }
-type VariationModifier = 'always' | 'ctrl' | 'shift' | 'alt' | 'meta' | 'unless_ctrl' | 'unless_shift' | 'unless_alt'
+type VariationModifier =
+	| 'always'
+	| 'ctrl'
+	| 'shift'
+	| 'alt'
+	| 'meta'
+	| 'unless_ctrl'
+	| 'unless_shift'
+	| 'unless_alt'
 type ModifierKey = 'ctrl' | 'shift' | 'alt' | 'meta'
 /**
  * A customizable keybind
@@ -37,29 +45,29 @@ declare class Keybind {
 	shift?: boolean
 	alt?: boolean
 	variations?: {
-		[key: string]: {name: string, description?: string}
+		[key: string]: { name: string; description?: string }
 	}
-	set(keys: KeybindKeys): this;
+	set(keys: KeybindKeys): this
 	/**
 	 * Unassign the assigned key
 	 */
-	clear(): this;
+	clear(): this
 	/**
 	 * Save any changes to local storage
 	 * @param save Save all keybinding changes to local storage. Set to fales if updating multiple at once
 	 */
-	save(save?: false): this;
+	save(save?: false): this
 	/**
 	 * Assign an action to the keybind
 	 * @param id ID of the action
 	 * @param sub_id sub keybind ID
 	 */
-	setAction(id: string, sub_id?: string): this | undefined;
+	setAction(id: string, sub_id?: string): this | undefined
 	/**
 	 * Get display text showing the keybind
 	 * @param formatted If true, the return string will include HTML formatting
 	 */
-	getText(formatted?: boolean): string;
+	getText(formatted?: boolean): string
 	/**
 	 * Get the name of the bound key
 	 */
@@ -67,39 +75,39 @@ declare class Keybind {
 	/**
 	 * Check if a key is assigned
 	 */
-	hasKey(): boolean;
+	hasKey(): boolean
 	/**
 	 * Test if the keybind would be triggered by the event
 	 */
-	isTriggered(event: Event): boolean;
+	isTriggered(event: Event): boolean
 	/**
 	 * Test which variation would be triggered by the event. Returns the ID of the variation if triggered
 	 * @param event The event to test
 	 */
-	additionalModifierTriggered(event: Event): string | undefined;
+	additionalModifierTriggered(event: Event): string | undefined
 	/**
 	 * Test if a variation would be triggered by the event
 	 * @param event The event to test
 	 * @param variation The variation to test againts
 	 */
-	additionalModifierTriggered(event: Event, variation: string): boolean;
+	additionalModifierTriggered(event: Event, variation: string): boolean
 	/**
 	 * Open a UI to let the user record a new key combination
 	 */
-	record(): this;
+	record(): this
 	/**
 	 * Stop recording a new key combination
 	 */
-	stopRecording(): this;
+	stopRecording(): this
 	/**
 	 * Returns the label of the keybinding
 	 */
-	toString(): string;
+	toString(): string
 
 	/**
 	 * Load an included keymap by ID
-	 * @param id 
-	 * @param from_start_screen 
+	 * @param id
+	 * @param from_start_screen
 	 */
 	static loadKeymap(id: string, from_start_screen?: boolean): void | true
 	/**
@@ -110,14 +118,14 @@ declare class Keybind {
 interface KeybindItemOptions {
 	keybind?: Keybind
 	variations?: {
-		[key: string]: {name: string, description?: string}
+		[key: string]: { name: string; description?: string }
 	}
 }
 declare class KeybindItem extends Deletable {
 	constructor(id: string, options: KeybindItemOptions)
 	keybind: Keybind
 	variations?: {
-		[key: string]: {name: string, description?: string}
+		[key: string]: { name: string; description?: string }
 	}
 }
 

--- a/types/action.d.ts
+++ b/types/action.d.ts
@@ -268,6 +268,10 @@ declare global {
 		 */
 		trigger(event?: Event): boolean
 		updateKeybindingLabel(): this
+		/**
+		 * Change the name of the action
+		 */
+		setName(name: string): void
 		/** Change the icon of the action */
 		setIcon(icon: IconString): void
 		toggleLinkedSetting(change: any): void

--- a/types/action.d.ts
+++ b/types/action.d.ts
@@ -130,7 +130,7 @@ declare class KeybindItem extends Deletable {
 }
 
 declare class MenuSeparator {
-	constructor(name?: string)
+	constructor(id?: string, label?: string)
 }
 type ActionEventName =
 	| 'delete'

--- a/types/action.d.ts
+++ b/types/action.d.ts
@@ -122,7 +122,7 @@ declare class KeybindItem extends Deletable {
 }
 
 declare class MenuSeparator {
-	constructor()
+	constructor(name?: string)
 }
 type ActionEventName =
 	| 'delete'

--- a/types/action.d.ts
+++ b/types/action.d.ts
@@ -537,7 +537,7 @@ declare class Toolbar {
 	build(data: any, force: any): this
 	contextmenu(event: Event): void
 	editMenu(): this
-	add(action: any, position: any): this
+	add(action: any, position?: number): this
 	remove(action: any): this
 	update(): this
 	toPlace(place: any): this

--- a/types/animation.d.ts
+++ b/types/animation.d.ts
@@ -91,6 +91,8 @@ declare class _Animation extends AnimationItem {
 	saved_name?: string
 	selected: boolean
 	type: string
+	menu: Menu
+	file_menu: Menu
 }
 
 interface MolangAutoCompletionItem {
@@ -122,6 +124,7 @@ declare namespace Animator {
 	 * @param animation_filter List of names of animations to import
 	 */
 	function loadFile(file: any, animation_filter?: string[]): void
+	function exportAnimationFile(path: string): void
 	function resetLastValues(): void
 	function autocompleteMolang(
 		text: string,

--- a/types/animation.d.ts
+++ b/types/animation.d.ts
@@ -31,6 +31,27 @@ interface AnimationUndoCopy {
 	selected: any
 }
 
+/**
+ *
+ * ⚠️ This will not provide correct type information! ⚠️
+ *
+ * Use {@link Blockbench.Animation} instead for TypeScript support.
+ *
+ * Blockbench overwrites libdom's {@link Animation} type with its own `Animation` Class, but TypeScript doesn't include a way to overwrite UMD global types.
+ * To get around this, we changed the name of this class type declaration to `_Animation` and use that in the type definitions.
+ */
+interface Animation {}
+
+/**
+ * ⚠️ THIS IS TYPE ONLY ⚠️
+ *
+ * **It does not exist** in Blockbench at Run-time. Use {@link Blockbench.Animation} instead.
+ *
+ * Blockbench overwrites libdom's {@link Animation} type with its own `Animation` Class, but TypeScript doesn't include a way to overwrite UMD global types.
+ * To get around this, we changed the name of this class type declaration to `_Animation` and use that in the type definitions.
+ *
+ * @deprecated
+ */
 declare class _Animation extends AnimationItem {
 	constructor(data?: AnimationOptions)
 	extend(data?: AnimationOptions): this

--- a/types/canvas.d.ts
+++ b/types/canvas.d.ts
@@ -248,7 +248,10 @@ interface NodePreviewControllerOptions {
 	updateHighlight?(element: OutlinerNode, ...args: any[]): void
 }
 declare class NodePreviewController {
-	constructor(type: typeof OutlinerElement | typeof OutlinerNode, options: NodePreviewControllerOptions)
+	constructor(
+		type: typeof OutlinerElement | typeof OutlinerNode,
+		options: NodePreviewControllerOptions
+	)
 	type: typeof OutlinerNode
 	events: {
 		[event_name: string]: ((data: any) => void)[]

--- a/types/collection.d.ts
+++ b/types/collection.d.ts
@@ -68,7 +68,7 @@ declare class Collection {
 	/**
 	 * Get all collections
 	 */
-	static all(): Collection[]
+	static all: Collection[]
 	/**
 	 * Get selected collections
 	 */

--- a/types/collection.d.ts
+++ b/types/collection.d.ts
@@ -10,7 +10,7 @@ interface CollectionOptions {
  * Collections are "selection presets" for a set of groups and elements in your project, independent from outliner hierarchy
  */
 declare class Collection {
-    constructor(data?: CollectionOptions, uuid?: string);
+	constructor(data?: CollectionOptions, uuid?: string)
 
 	selected: boolean
 	/**
@@ -22,48 +22,48 @@ declare class Collection {
 	export_path: string
 	visibility: boolean
 
-    extend(data: CollectionOptions): this;
-    select(event?: Event): this;
-    clickSelect(event: Event): void;
+	extend(data: CollectionOptions): this
+	select(event?: Event): this
+	clickSelect(event: Event): void
 	/**
 	 * Get all direct children
 	 */
-    getChildren(): OutlinerNode[];
-    add(): this;
+	getChildren(): OutlinerNode[]
+	add(): this
 	/**
 	 * Adds the current outliner selection to this collection
 	 */
-    addSelection(): this;
+	addSelection(): this
 	/**
 	 * Returns the visibility of the first contained node that supports visibility. Otherwise returns true.
 	 */
-    getVisibility(): boolean;
+	getVisibility(): boolean
 	/**
 	 * Get all children, including indirect ones
 	 */
-    getAllChildren(): any[];
+	getAllChildren(): any[]
 	/**
 	 * Toggle visibility of everything in the collection
 	 * @param event If the alt key is pressed, the result is inverted and the visibility of everything but the collection will be toggled
 	 */
-    toggleVisibility(event: Event): void;
+	toggleVisibility(event: Event): void
 	/**
 	 * Opens the context menu
 	 */
-    showContextMenu(event: Event): this;
-    getUndoCopy(): {
-        uuid: string;
-        index: number;
-		[key: string]: any;
-    };
-    getSaveCopy(): {
-        uuid: string;
-		[key: string]: any;
-    };
+	showContextMenu(event: Event): this
+	getUndoCopy(): {
+		uuid: string
+		index: number
+		[key: string]: any
+	}
+	getSaveCopy(): {
+		uuid: string
+		[key: string]: any
+	}
 	/**
 	 * Opens the properties dialog
 	 */
-    propertiesDialog(): void;
+	propertiesDialog(): void
 
 	/**
 	 * Get all collections

--- a/types/cube.d.ts
+++ b/types/cube.d.ts
@@ -18,7 +18,7 @@ interface ICubeOptions {
 	 * UV position for box UV mode
 	 */
 	uv_offset?: ArrayVector2
-	faces?: Record<CardinalDirection, CubeFaceOptions>
+	faces?: Partial<Record<CardinalDirection, CubeFaceOptions>>
 }
 
 declare class Cube extends OutlinerElement {

--- a/types/cube.d.ts
+++ b/types/cube.d.ts
@@ -18,7 +18,7 @@ interface ICubeOptions {
 	 * UV position for box UV mode
 	 */
 	uv_offset: ArrayVector2
-	faces: Partial<Record<CardinalDirection, CubeFaceOptions>>
+	faces: Record<CardinalDirection, CubeFaceOptions>
 }
 
 declare class Cube extends OutlinerElement {

--- a/types/cube.d.ts
+++ b/types/cube.d.ts
@@ -2,27 +2,27 @@
 type CardinalDirection = 'north' | 'south' | 'east' | 'west' | 'up' | 'down'
 
 interface ICubeOptions {
-	name: string
-	autouv: 0 | 1 | 2
-	shade: boolean
-	mirror_uv: boolean
-	inflate: number
-	color: number
-	visibility: boolean
-	from: ArrayVector3
-	to: ArrayVector3
-	rotation: ArrayVector3
-	origin: ArrayVector3
-	box_uv: boolean
+	name?: string
+	autouv?: 0 | 1 | 2
+	shade?: boolean
+	mirror_uv?: boolean
+	inflate?: number
+	color?: number
+	visibility?: boolean
+	from?: ArrayVector3
+	to?: ArrayVector3
+	rotation?: ArrayVector3
+	origin?: ArrayVector3
+	box_uv?: boolean
 	/**
 	 * UV position for box UV mode
 	 */
-	uv_offset: ArrayVector2
-	faces: Record<CardinalDirection, CubeFaceOptions>
+	uv_offset?: ArrayVector2
+	faces?: Record<CardinalDirection, CubeFaceOptions>
 }
 
 declare class Cube extends OutlinerElement {
-	constructor(options: Partial<ICubeOptions>, uuid?: string)
+	constructor(options: ICubeOptions, uuid?: string)
 	name: string
 	uuid: string
 	color: any
@@ -66,7 +66,7 @@ declare class Cube extends OutlinerElement {
 		}
 	}
 
-	extend(options: Partial<ICubeOptions>): this
+	extend(options: ICubeOptions): this
 	/**
 	 * Calculates and returns the size of a cube across a certain axis. If the axis argument is omitted, it returns all sizes as an array vector.
 	 */

--- a/types/dialog.d.ts
+++ b/types/dialog.d.ts
@@ -114,7 +114,7 @@ type InputFormConfig = {
 declare class InputForm {
 	constructor(form_config: InputFormConfig)
 	form_config: InputFormConfig
-	form_data: {[formElement: string]: {}}
+	form_data: { [formElement: string]: {} }
 	node: HTMLDivElement
 	max_label_width: number
 	uses_wide_inputs: boolean
@@ -354,7 +354,7 @@ declare class Dialog {
 	setFormValues(values: { [key: string]: FormResultValue }, update: boolean): void
 	/**
 	 * Set whether the dialog form inputs are toggled on or off. See "toggle_enabled"
-	 * @param values 
+	 * @param values
 	 * @param update Whether to update the dialog (call onFormChange) after setting the values. Default is true. Set to false when called from onFormChange
 	 */
 	setFormToggles(values: { [key: string]: boolean }, update: boolean): void

--- a/types/format.d.ts
+++ b/types/format.d.ts
@@ -220,7 +220,7 @@ interface FormatOptions {
 	/**
 	 * Set the default render sides for textures
 	 */
-	render_sides: 'front' | 'double' | 'back' | (() => ('front' | 'double' | 'back'))
+	render_sides: 'front' | 'double' | 'back' | (() => 'front' | 'double' | 'back')
 
 	/**
 	 * Options to limit the size of cubes
@@ -250,8 +250,6 @@ declare class ModelFormat extends Deletable implements FormatOptions {
 	onFormatPage?(): void
 	onStart?(): void
 	onSetup?(): void
-
-	
 
 	codec?: Codec
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -132,7 +132,7 @@ declare global {
 
 		V3_set(x: number, y: number, z: number): this
 		V3_set(values: ArrayVector3): this
-		//V3_set(value: THREE.Vector3): this
+		V3_set(value: THREE.Vector3): this
 		V3_add(x: number, y: number, z: number): this
 		V3_add(values: ArrayVector3): this
 		V3_add(value: THREE.Vector3): this

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -132,7 +132,7 @@ declare global {
 
 		V3_set(x: number, y: number, z: number): this
 		V3_set(values: ArrayVector3): this
-		V3_set(value: THREE.Vector3): this
+		// V3_set(value: THREE.Vector3): this
 		V3_add(x: number, y: number, z: number): this
 		V3_add(values: ArrayVector3): this
 		V3_add(value: THREE.Vector3): this

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,7 +1,7 @@
 /// <reference path="./blockbench.d.ts"/>
 
 declare global {
-	const Prism: typeof import('prismjs')
+	// const Prism: typeof import('prismjs')
 	const scene: THREE.Scene
 	const Transformer: any
 	const electron: typeof import('electron')
@@ -15,7 +15,6 @@ declare global {
 	const PathModule: typeof import('path')
 	const fs: typeof import('fs')
 
-	const tinycolor: typeof import('tinycolor2')
 	const DOMPurify: typeof import('dompurify')
 
 	let selected: OutlinerElement[]

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -129,21 +129,21 @@ declare global {
 		 */
 		overlap(arr: Array<any>): number
 
-		V3_set(x: number, y: number, z: number): this
-		V3_set(values: ArrayVector3): this
+		V3_set(x: number, y: number, z: number): ArrayVector3
+		V3_set(values: ArrayVector3): ArrayVector3
 		// V3_set(value: THREE.Vector3): this
-		V3_add(x: number, y: number, z: number): this
-		V3_add(values: ArrayVector3): this
-		V3_add(value: THREE.Vector3): this
-		V3_subtract(x: number, y: number, z: number): this
-		V3_subtract(values: ArrayVector3): this
-		V3_subtract(value: THREE.Vector3): this
-		V3_multiply(x: number, y: number, z: number): this
-		V3_multiply(values: ArrayVector3): this
-		V3_multiply(value: THREE.Vector3): this
-		V3_divide(x: number, y: number, z: number): this
-		V3_divide(values: ArrayVector3): this
-		V3_divide(value: THREE.Vector3): this
+		V3_add(x: number, y: number, z: number): ArrayVector3
+		V3_add(values: ArrayVector3): ArrayVector3
+		V3_add(value: THREE.Vector3): ArrayVector3
+		V3_subtract(x: number, y: number, z: number): ArrayVector3
+		V3_subtract(values: ArrayVector3): ArrayVector3
+		V3_subtract(value: THREE.Vector3): ArrayVector3
+		V3_multiply(x: number, y: number, z: number): ArrayVector3
+		V3_multiply(values: ArrayVector3): ArrayVector3
+		V3_multiply(value: THREE.Vector3): ArrayVector3
+		V3_divide(x: number, y: number, z: number): ArrayVector3
+		V3_divide(values: ArrayVector3): ArrayVector3
+		V3_divide(value: THREE.Vector3): ArrayVector3
 		V3_toThree(): THREE.Vector3
 	}
 
@@ -152,4 +152,5 @@ declare global {
 	}
 }
 
-export {}
+export { }
+

--- a/types/group.d.ts
+++ b/types/group.d.ts
@@ -22,18 +22,20 @@ interface GroupOptions {
 declare class Group extends OutlinerNode {
 	constructor(options: Partial<GroupOptions> | string)
 	/**
-	 * Returns the first selected group. Depretated, use Group.multi_selected. In the future this will return an array of selected groups instead.
-	 * @deprecated
+	 * Returns the first selected group.
+	 * In the future this will return an array of selected groups instead.
+	 * @deprecated Use {@link Group.multi_selected} instead!
 	 */
-	static selected: Group
+	static selected: Group | undefined
 	/**
-	 * The group that's the first in the list of selected groups
+	 * The first group in {@link Group.multi_selected}
 	 */
-	static first_selected: Group
+	static first_selected: Group | undefined
 	/**
-	 * The list of selected groups. Note that this only includes directly selected groups, not groups that are selected because the parent is selected
+	 * A list of directly selected groups.
+	 * @Note This only includes directly selected groups, not groups that are selected because the parent is selected
 	 */
-	static multi_selected: Group
+	static multi_selected: Group[]
 	/**
 	 * All groups in the current project
 	 */

--- a/types/interface.d.ts
+++ b/types/interface.d.ts
@@ -76,17 +76,18 @@ declare namespace Interface {
 	const left_bar: HTMLElement
 
 	namespace CustomElements {
-		class SelectInput {
+		class SelectInput<T extends Record<string, string>> {
 			node: HTMLElement
 			constructor(
 				id: string,
 				options: {
-					value?: string
-					default?: string
-					options: { [key: string]: string }
-					onChange?(value: any): void
+					value?: T[keyof T]
+					default?: T[keyof T]
+					options: T
+					onChange?(value: T[keyof T]): void
 				}
 			)
+			set(value: T[keyof T]): void
 		}
 		const ResizeLine: any
 	}

--- a/types/interface.d.ts
+++ b/types/interface.d.ts
@@ -76,15 +76,18 @@ declare namespace Interface {
 	const left_bar: HTMLElement
 
 	namespace CustomElements {
-		function SelectInput(
-			id: string,
-			options: {
-				value?: string
-				default?: string
-				options: { [key: string]: string }
-				onChange?(): void
-			}
-		): HTMLElement
+		class SelectInput {
+			node: HTMLElement
+			constructor(
+				id: string,
+				options: {
+					value?: string
+					default?: string
+					options: { [key: string]: string }
+					onChange?(value: string): void
+				}
+			)
+		}
 		const ResizeLine: any
 	}
 }

--- a/types/interface.d.ts
+++ b/types/interface.d.ts
@@ -84,7 +84,7 @@ declare namespace Interface {
 					value?: string
 					default?: string
 					options: { [key: string]: string }
-					onChange?(value: string): void
+					onChange?(value: any): void
 				}
 			)
 		}

--- a/types/menu.d.ts
+++ b/types/menu.d.ts
@@ -93,7 +93,6 @@ declare namespace MenuBar {
 		help: Menu
 		[id: string]: Menu
 	}
-	const structure: MenuItem[]
 	/**
 	 * Adds an action to the menu structure
 	 * @param action Action to add

--- a/types/menu.d.ts
+++ b/types/menu.d.ts
@@ -93,6 +93,7 @@ declare namespace MenuBar {
 		help: Menu
 		[id: string]: Menu
 	}
+	const structure: MenuItem[]
 	/**
 	 * Adds an action to the menu structure
 	 * @param action Action to add

--- a/types/misc.d.ts
+++ b/types/misc.d.ts
@@ -277,3 +277,6 @@ declare const Pressing: {
 }
 
 declare function isStringNumber(value: any): boolean
+
+declare function marked(text: string): string
+declare function pureMarked(text: string): string

--- a/types/mode.d.ts
+++ b/types/mode.d.ts
@@ -1,9 +1,12 @@
 /// <reference path="./blockbench.d.ts"/>
 
 interface ModeOptions {
+	id: string
 	name: string
+	icon?: string
 	default_tool?: string
 	selectElements?: boolean
+	category?: string
 	/**
 	 * Hide certain types of nodes in the outliner, like cubes and meshes in animation mode
 	 */
@@ -18,6 +21,7 @@ interface ModeOptions {
 }
 declare class Mode extends KeybindItem {
 	constructor(id: string, options: ModeOptions)
+	constructor(options: ModeOptions)
 	id: string
 	name: string
 

--- a/types/outliner.d.ts
+++ b/types/outliner.d.ts
@@ -58,7 +58,7 @@ declare class OutlinerNode {
 	 * @param event Mouse event, determines where the context menu spawns.
 	 */
 	showContexnu(event: Event | HTMLElement): this
-	getSaveCopy?(project?: boolean): Record<string, any>
+	getSaveCopy?(...args: any[]): Record<string, any>
 	sanitizeName(): string
 
 	static uuids: {

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -97,8 +97,6 @@ declare class BBPlugin {
 	disabled: boolean
 	title: string
 	author: string
-	id: string
-	disabled: boolean
 	/**
 	 * Description text in the plugin browser
 	 */
@@ -151,12 +149,6 @@ declare class BBPlugin {
 	getIcon(): string
 
 	toggleDisabled(): void
-}
-
-declare class Plugins {
-	static all: BBPlugin[]
-	static installed: BBPlugin[]
-	static dialog: Dialog
 }
 
 type PluginInstalledData = {

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -97,6 +97,8 @@ declare class BBPlugin {
 	disabled: boolean
 	title: string
 	author: string
+	id: string
+	disabled: boolean
 	/**
 	 * Description text in the plugin browser
 	 */
@@ -144,6 +146,17 @@ declare class BBPlugin {
 	onuninstall(): void
 
 	static register(id: string, options: PluginOptions): BBPlugin
+
+	hasImageIcon(): boolean
+	getIcon(): string
+
+	toggleDisabled(): void
+}
+
+declare class Plugins {
+	static all: BBPlugin[]
+	static installed: BBPlugin[]
+	static dialog: Dialog
 }
 
 type PluginInstalledData = {

--- a/types/shared_actions.d.ts
+++ b/types/shared_actions.d.ts
@@ -1,8 +1,8 @@
 /**
  * Shared Actions is a system in Blockbench to allow actions (including in toolbars, menus, via action control, or keybinding) to run different code in different cases, such as in different modes or different panels.
  * As an example, the "Duplicate" action runs code to duplicate elements when used in the outliner, and duplicates textures when used in the textures panel.
- * 
- * 
+ *
+ *
  * Handlers can be added for existing actions like this:
 
 ### Example:
@@ -24,12 +24,14 @@
 		}
 	})
 ```
- * 
+ *
  */
 declare namespace SharedActions {
 	const checks: {
 		[id: SharedActionID]: SharedActionHandler
 	}
+
+	const actions: Record<string, Array<SharedActionHandler>>
 
 	/**
 	 * Add a new handler to a shared action

--- a/types/texture_group.d.ts
+++ b/types/texture_group.d.ts
@@ -1,7 +1,6 @@
 /// <reference path="./blockbench.d.ts"/>
 
 interface TextureGroupData {
-	uuid?: string
 	name?: string
 	is_material?: boolean
 	material_config?: TextureGroupMaterialConfigData

--- a/types/texture_group.d.ts
+++ b/types/texture_group.d.ts
@@ -1,6 +1,6 @@
 /// <reference path="./blockbench.d.ts"/>
 
-interface TextureGroupData {
+interface TextureGroupOptions {
 	name?: string
 	is_material?: boolean
 	material_config?: TextureGroupMaterialConfigData
@@ -12,7 +12,7 @@ interface TextureGroupData {
 declare class TextureGroup {
 	static all: TextureGroup[]
 
-	constructor(data?: TextureGroupData, uuid?: string)
+	constructor(data?: TextureGroupOptions, uuid?: string)
 	uuid: string
 	name: string
 	folded: boolean
@@ -25,7 +25,7 @@ declare class TextureGroup {
 	 */
 	material_config: TextureGroupMaterialConfig
 	get material(): THREE.MeshStandardMaterial
-	extend(data: TextureGroupData): this
+	extend(data: TextureGroupOptions): this
 	add(): this
 	select(): this
 	remove(): void

--- a/types/texture_group.d.ts
+++ b/types/texture_group.d.ts
@@ -1,73 +1,72 @@
 /// <reference path="./blockbench.d.ts"/>
 
-
 interface TextureGroupData {
-    name?: string
-    is_material?: boolean
-    material_config?: TextureGroupMaterialConfigData
+	name?: string
+	is_material?: boolean
+	material_config?: TextureGroupMaterialConfigData
 }
 
 /**
  * A way to group textures. Texture groups can also be used to represent materials in enabled formats
  */
 declare class TextureGroup {
-    constructor(data?: TextureGroupData, uuid?: string);
-    uuid: string
-    name: string
-    folded: boolean
-    /**
-     * If true, the texture group works as a material
-     */
-    is_material: boolean
-    /**
-     * Material configuration
-     */
-    material_config: TextureGroupMaterialConfig
-    get material(): THREE.MeshStandardMaterial;
-    extend(data: TextureGroupData): this;
-    add(): this;
-    select(): this;
-    remove(): void;
-    showContextMenu(event: Event): void;
-    rename(): this;
-    getTextures(): Texture[];
-    getUndoCopy(): {
-        uuid: string;
-        index: number;
-        material_config: {};
-    };
-    getSaveCopy(): {
-        uuid: string;
-        material_config: {};
-    };
-    updateMaterial(): void;
-    getMaterial(): THREE.MeshStandardMaterial;
+	constructor(data?: TextureGroupData, uuid?: string)
+	uuid: string
+	name: string
+	folded: boolean
+	/**
+	 * If true, the texture group works as a material
+	 */
+	is_material: boolean
+	/**
+	 * Material configuration
+	 */
+	material_config: TextureGroupMaterialConfig
+	get material(): THREE.MeshStandardMaterial
+	extend(data: TextureGroupData): this
+	add(): this
+	select(): this
+	remove(): void
+	showContextMenu(event: Event): void
+	rename(): this
+	getTextures(): Texture[]
+	getUndoCopy(): {
+		uuid: string
+		index: number
+		material_config: {}
+	}
+	getSaveCopy(): {
+		uuid: string
+		material_config: {}
+	}
+	updateMaterial(): void
+	getMaterial(): THREE.MeshStandardMaterial
 }
 
 interface TextureGroupMaterialConfigData {
-    color_value?: [number, number, number, number]
-    mer_value?: [number, number, number]
-    saved?: boolean
+	color_value?: [number, number, number, number]
+	mer_value?: [number, number, number]
+	saved?: boolean
 }
 declare class TextureGroupMaterialConfig {
-    constructor(texture_group: TextureGroup, data: TextureGroupMaterialConfigData);
-    color_value: [number, number, number, number]
-    mer_value: [number, number, number]
-    saved: boolean
-    menu: Menu
-    texture_group: TextureGroup
+	constructor(texture_group: TextureGroup, data: TextureGroupMaterialConfigData)
+	color_value: [number, number, number, number]
+	mer_value: [number, number, number]
+	saved: boolean
+	menu: Menu
+	texture_group: TextureGroup
 
-    extend(data: TextureGroupMaterialConfigData): this;
-    getUndoCopy(): {};
-    getSaveCopy(): {};
-    compileForBedrock(): {
-        format_version: string;
-        "minecraft:texture_set": {};
-    };
-    getFilePath(): string;
-    getFileName(extension?: boolean): string;
-    save(): void;
-    showContextMenu(event: Event): void;
-    propertiesDialog(): void;
+	extend(data: TextureGroupMaterialConfigData): this
+	getUndoCopy(): {}
+	getSaveCopy(): {}
+	compileForBedrock(): {
+		format_version: string
+		'minecraft:texture_set': {}
+	}
+	getFilePath(): string
+	getFileName(extension?: boolean): string
+	save(): void
+	showContextMenu(event: Event): void
+	propertiesDialog(): void
 }
-declare function importTextureSet(file: any): void;
+declare function importTextureSet(file: any): void

--- a/types/texture_group.d.ts
+++ b/types/texture_group.d.ts
@@ -1,6 +1,7 @@
 /// <reference path="./blockbench.d.ts"/>
 
 interface TextureGroupData {
+	uuid?: string
 	name?: string
 	is_material?: boolean
 	material_config?: TextureGroupMaterialConfigData

--- a/types/texture_group.d.ts
+++ b/types/texture_group.d.ts
@@ -1,6 +1,7 @@
 /// <reference path="./blockbench.d.ts"/>
 
 interface TextureGroupOptions {
+	uuid?: string
 	name?: string
 	is_material?: boolean
 	material_config?: TextureGroupMaterialConfigData
@@ -12,7 +13,7 @@ interface TextureGroupOptions {
 declare class TextureGroup {
 	static all: TextureGroup[]
 
-	constructor(data?: TextureGroupOptions, uuid?: string)
+	constructor(data?: Omit<TextureGroupOptions, 'uuid'>, uuid?: string)
 	uuid: string
 	name: string
 	folded: boolean
@@ -32,15 +33,8 @@ declare class TextureGroup {
 	showContextMenu(event: Event): void
 	rename(): this
 	getTextures(): Texture[]
-	getUndoCopy(): {
-		uuid: string
-		index: number
-		material_config: {}
-	}
-	getSaveCopy(): {
-		uuid: string
-		material_config: {}
-	}
+	getUndoCopy(): Required<TextureGroupOptions>
+	getSaveCopy(): Omit<TextureGroupOptions, 'is_material' | 'uuid'>
 	updateMaterial(): void
 	getMaterial(): THREE.MeshStandardMaterial
 }

--- a/types/texture_group.d.ts
+++ b/types/texture_group.d.ts
@@ -11,6 +11,8 @@ interface TextureGroupData {
  * A way to group textures. Texture groups can also be used to represent materials in enabled formats
  */
 declare class TextureGroup {
+	static all: TextureGroup[]
+
 	constructor(data?: TextureGroupData, uuid?: string)
 	uuid: string
 	name: string

--- a/types/textures.d.ts
+++ b/types/textures.d.ts
@@ -150,6 +150,8 @@ declare class Texture {
 	 * Texture image element
 	 */
 	img: HTMLImageElement
+	get material(): THREE.ShaderMaterial
+	set material(value: THREE.ShaderMaterial)
 
 	relative_path?: string
 	readonly material: THREE.ShaderMaterial

--- a/types/textures.d.ts
+++ b/types/textures.d.ts
@@ -132,9 +132,9 @@ declare global {
 		saved: boolean
 		/**
 		 * Whether the latest version of the texture is currently loaded from and linked to a file on disk, or held in memory as bitmap data
-		 * @deprecated Use texture.internal instead
+		 * @deprecated Use {@link Texture.internal} instead
 		 */
-		mode: 'link' | 'bitmap'
+		mode: never
 		/**
 		 * If true, the texture is loaded internally. If false, the texture is loaded directly from a file
 		 */

--- a/types/textures.d.ts
+++ b/types/textures.d.ts
@@ -87,13 +87,6 @@ declare global {
 		readonly display_height: number
 		readonly ratio: number
 		static selected?: Texture
-		readonly _static: {
-			properties: {
-				material: ShaderMaterial
-				selection: IntMatrix
-				watcher?: FSWatcher
-			}
-		}
 
 		path?: string
 		name: string

--- a/types/textures.d.ts
+++ b/types/textures.d.ts
@@ -1,458 +1,481 @@
 /// <reference path="./blockbench.d.ts"/>
 
-interface TextureData {
-	path?: string
-	name?: string
-	/** 
-	 * Relative path to the file's directory, used by some formats such as Java Block/Item
-	 * */
-	folder?: string
-	namespace?: string
-	/**
-	 * Texture ID or key, used by some formats. By default this is a number that increases with every texture that is added
-	 * */
-	id?: string
-	/**
-	 * Whether the texture is used for the models particle system. Used by some formats such as Java Block/Item
-	 * */
-	particle?: boolean
-	visible?: boolean
-	render_mode?: 'default' | 'emissive' | 'additive' | 'layered' | string
-	render_sides?: 'auto' | 'front' | 'double' | string
-	pbr_channel?: 'color' | 'normal' | 'height' | 'mer'
+import type { FSWatcher } from 'fs'
+import type { ShaderMaterial } from 'three'
 
-	/**
-	 * Texture animation frame time
-	 * */
-	frame_time?: number
-	frame_order_type?: 'custom' | 'loop' | 'backwards' | 'back_and_forth'
-	/**
-	 * Custom frame order
-	 * */
-	frame_order?: string
-	/**
-	 * Interpolate between frames
-	 * */
-	frame_interpolate?: boolean
-	/**
-	 * Whether the texture is saved
-	 */
-	saved?: boolean
-	/**
-	 * Flag to indicate that the texture was manually resized, and on load it should not try to automatically adjust UV size
-	 */
-	keep_size?: boolean
-	source?: string
-	width?: number
-	height?: number
-	standalone?: boolean
-}
-interface TextureEditOptions {
-	/**
-	 * Edit method. 'canvas' is default
-	 */
-	method?: 'canvas' | 'jimp'
-	/**
-	 * Name of the undo entry that is created
-	 */
-	edit_name?: string
-	/**
-	 * Whether to use the cached canvas/jimp instance
-	 */
-	use_cache?: boolean
-	/**
-	 * If true, no undo point is created. Default is false
-	 */
-	no_undo?: boolean
-	/**
-	 * If true, the texture is not updated visually
-	 */
-	no_update?: boolean
-	no_undo_init?: boolean
-	no_undo_finish?: boolean
-}
+declare global {
+	interface TextureData {
+		path?: string
+		uuid?: string
+		name?: string
+		/**
+		 * Relative path to the file's directory, used by some formats such as Java Block/Item
+		 * */
+		folder?: string
+		namespace?: string
+		/**
+		 * Texture ID or key, used by some formats. By default this is a number that increases with every texture that is added
+		 * */
+		id?: string
+		/**
+		 * Whether the texture is used for the models particle system. Used by some formats such as Java Block/Item
+		 * */
+		particle?: boolean
+		visible?: boolean
+		render_mode?: 'default' | 'emissive' | 'additive' | 'layered' | string
+		render_sides?: 'auto' | 'front' | 'double' | string
+		pbr_channel?: 'color' | 'normal' | 'height' | 'mer'
 
-/**
- * A texture combines the functionality of material, texture, and image, in one. Textures can be linked to files on the local hard drive, or hold the information in RAM.
- */
-declare class Texture {
-	constructor(data?: TextureData, uuid?: string)
-	readonly frameCount: number | undefined
-	readonly display_height: number
-	readonly ratio: number
-
-	path?: string
-	name: string
-	/** Relative path to the file's directory, used by some formats such as Java Block/Item*/
-	folder: string
-	namespace: string
-	/** Texture ID or key, used by some formats. By default this is a number that increases with every texture that is added */
-	id: string
-	/** Whether the texture is used for the models particle system. Used by some formats such as Java Block/Item */
-	particle: boolean
-	render_mode: 'default' | 'emissive' | 'additive' | 'layered' | string
-	render_sides: 'auto' | 'front' | 'double' | string
-	pbr_channel: 'color' | 'normal' | 'height' | 'mer'
-
-	/** Texture animation frame time */
-	frame_time: number
-	frame_order_type: 'custom' | 'loop' | 'backwards' | 'back_and_forth'
-	/** Custom frame order */
-	frame_order: string
-	/** Interpolate between frames */
-	frame_interpolate: boolean
-
-	/** HTML-style source of the texture's displayed data. Can be a path (desktop app only), or a base64 data URL */
-	source: string
-	selected?: boolean
-	show_icon: boolean
-	error: number
-	/** Whether the texture is visible. Used for layered textures mode */
-	visible: boolean
-
-	width: number
-	height: number
-	uv_width: number
-	uv_height: number
-	currentFrame: number
-	saved: boolean
-	/**
-	 * Whether the latest version of the texture is currently loaded from and linked to a file on disk, or held in memory as bitmap data
-	 * @deprecated Use texture.internal instead
-	 */
-	mode: 'link' | 'bitmap'
-	/**
-	 * If true, the texture is loaded internally. If false, the texture is loaded directly from a file
-	 */
-	internal: boolean
-	uuid: UUID
-
-	/**
-	 * Texture selection in paint mode
-	 */
-	selection: IntMatrix
-	layers: TextureLayer[]
-	layers_enabled: boolean
-	/**
-	 * The UUID of the project to sync the texture to
-	 */
-	sync_to_project: UUID | ''
-
-	/**
-	 * The texture's associated canvas. Since 4.9, this is the main source of truth for textures in internal mode.
-	 */
-	canvas: HTMLCanvasElement
-	/**
-	 * The 2D context of the texture's associated canvas.
-	 */
-	ctx: CanvasRenderingContext2D
-	/**
-	 * Texture image element
-	 */
-	img: HTMLImageElement
-	get material(): THREE.ShaderMaterial
-	set material(value: THREE.ShaderMaterial)
-
-	relative_path?: string
-	readonly material: THREE.ShaderMaterial
-
-	getErrorMessage(): string
-	extend(data: TextureData): this
-
-	/**
-	 * Get the UV width of the texture if the format uses per texture UV size, otherwise get the project texture width
-	 */
-	getUVWidth(): number
-	/**
-	 * Get the UV height of the texture if the format uses per texture UV size, otherwise get the project texture height
-	 */
-	getUVHeight(): number
-	getUndoCopy(bitmap?: boolean): any
-	getSaveCopy(bitmap?: boolean): any
-	/**
-	 * Start listening for changes to the linked file. Desktop only
-	 */
-	startWatcher(): void
-	/**
-	 * Stop listening for changes to the linked file. Desktop only
-	 */
-	stopWatcher(): void
-	/**
-	 * Generate the Java Block/Item folder property from the file path
-	 */
-	generateFolder(): void
-	/**
-	 * Loads the texture from it's current source
-	 * @param cb Callback function
-	 */
-	load(cb?: () => {}): this
-	fromJavaLink(link: string, path_array: string[]): this
-	fromFile(file: { name: string; content?: string; path: string }): this
-	fromPath(path: string): this
-	fromDataURL(data_url: string): this
-	fromDefaultPack(): true | undefined
-	/**
-	 * Loads the default white error texture
-	 * @param error_id Sets the error ID of the texture
-	 */
-	loadEmpty(error_id?: number): this
-
-	updateSource(dataUrl: string): this
-	updateMaterial(): this
-
-	/**
-	 * Opens a dialog to replace the texture with another file
-	 * @param force If true, no warning appears of the texture has unsaved changes
-	 */
-	reopen(force: boolean): void
-	/**
-	 * Reloads the texture. Only works in the desktop app
-	 */
-	reloadTexture(): void
-	/**
-	 * Get the material that the texture displays. When previewing PBR, this will return the shared PBR material
-	 */
-	getMaterial(): THREE.ShaderMaterial | THREE.MeshStandardMaterial
-	/**
-	 * Get the texture's own material
-	 */
-	getOwnMaterial(): THREE.ShaderMaterial
-	/**
-	 * Selects the texture
-	 * @param event Click event during selection
-	 */
-	select(event?: Event): this
-	/**
-	 * Adds texture to the textures list and initializes it
-	 * @param undo If true, an undo point is created
-	 */
-	add(undo?: boolean): Texture
-	/**
-	 * Removes the texture
-	 * @param no_update If true, the texture is silently removed. The interface is not updated, no undo point is created
-	 */
-	remove(no_update?: boolean): void
-	toggleVisibility(): this
-	enableParticle(): this
-	/**
-	 * Enables 'particle' on this texture if it is not enabled on any other texture
-	 */
-	fillParticle(): this
-	/**
-	 * Applies the texture to the selected elements
-	 * @param all If true, the texture is applied to all faces of the elements. If 'blank', the texture is only applied to blank faces
-	 */
-	apply(all: true | false | 'blank'): this
-	/**
-	 * Shows the texture file in the file explorer
-	 */
-	openFolder(): this
-	/**
-	 * Opens the texture in the configured image editor
-	 */
-	openEditor(): this
-	showContextMenu(event: MouseEvent): void
-	openMenu(): void
-	resizeDialog(): this
-	/**
-	 * Scroll the texture list to this texture
-	 */
-	scrollTo(): void
-	save(as: any): this
-	/**
-	 * Returns the content of the texture as PNG as a base64 encoded string
-	 */
-	getBase64(): string
-	/**
-	 * Returns the content of the texture as PNG as a base64 encoded data URL
-	 */
-	getDataURL(): string
-	/**
-	 * Wrapper to do edits to the texture.
-	 * @param callback
-	 * @param options Editing options
-	 */
-	edit(
-		callback: (instance: HTMLCanvasElement | any) => void | HTMLCanvasElement,
-		options: TextureEditOptions
-	): void
-	menu: Menu
-	/**
-	 * Get the selected layer. If no layer is selected, returns the bottom layer
-	 */
-	getActiveLayer(): TextureLayer
-	activateLayers(undo?: boolean): void
-	/**
-	 * Turns the texture selection into a layer
-	 * @param undo Whether to create an undo entry
-	 * @param clone When true, the selection is copied into the new layer and also left on the original layer
-	 */
-	selectionToLayer(undo?: boolean, clone?: boolean): void
-	javaTextureLink(): string
-
-	getMCMetaContent(): {
-		animation?: {
-			frametime: number
-			width?: number
-			height?: number
-			interpolate?: boolean
-			frames?: number[]
-		}
+		/**
+		 * Texture animation frame time
+		 * */
+		frame_time?: number
+		frame_order_type?: 'custom' | 'loop' | 'backwards' | 'back_and_forth'
+		/**
+		 * Custom frame order
+		 * */
+		frame_order?: string
+		/**
+		 * Interpolate between frames
+		 * */
+		frame_interpolate?: boolean
+		/**
+		 * Whether the texture is saved
+		 */
+		saved?: boolean
+		/**
+		 * Flag to indicate that the texture was manually resized, and on load it should not try to automatically adjust UV size
+		 */
+		keep_size?: boolean
+		source?: string
+		width?: number
+		height?: number
+		standalone?: boolean
+		relative_path?: string
 	}
-	getAnimationFrameIndices(): number[]
+	interface TextureEditOptions {
+		/**
+		 * Edit method. 'canvas' is default
+		 */
+		method?: 'canvas' | 'jimp'
+		/**
+		 * Name of the undo entry that is created
+		 */
+		edit_name?: string
+		/**
+		 * Whether to use the cached canvas/jimp instance
+		 */
+		use_cache?: boolean
+		/**
+		 * If true, no undo point is created. Default is false
+		 */
+		no_undo?: boolean
+		/**
+		 * If true, the texture is not updated visually
+		 */
+		no_update?: boolean
+		no_undo_init?: boolean
+		no_undo_finish?: boolean
+	}
 
-	exportEmissionMap(): void
+	/**
+	 * A texture combines the functionality of material, texture, and image, in one. Textures can be linked to files on the local hard drive, or hold the information in RAM.
+	 */
+	class Texture {
+		constructor(data?: TextureData, uuid?: string)
+		readonly frameCount: number | undefined
+		readonly display_height: number
+		readonly ratio: number
+		static selected?: Texture
+		readonly _static: {
+			properties: {
+				material: ShaderMaterial
+				selection: IntMatrix
+				watcher?: FSWatcher
+			}
+		}
 
-	convertToInternal(data_url?: string): this
-	/**
-	 * Redraws the texture content from the layers
-	 * @param update_data_url If true, the texture source gets updated as well. This is slower, but is necessary at the end of an edit. During an edit, to preview changes, this can be false
-	 */
-	updateLayerChanges(update_data_url?: boolean): void
-	/**
-	 * Update everything after a content edit to the texture or one of the layers. Updates the material, the layers, marks the texture as unsaved, syncs changes to other projects
-	 */
-	updateChangesAfterEdit(): void
-	/**
-	 * Update the attached img element with the content from the texture's canvas
-	 */
-	updateImageFromCanvas(): void
-	/**
-	 * If layers are enabled, returns the active layer, otherwise returns the texture. Either way, the 'canvas', 'ctx', and 'offset' properties can be used from the returned object
-	 */
-	getActiveCanvas(): Texture | TextureLayer
-	/**
-	 * When editing the same texture in different tabs (via Edit In Blockbench option), sync changes that were made to the texture to other projects
-	 */
-	syncToOtherProject(): this
+		path?: string
+		name: string
+		/** Relative path to the file's directory, used by some formats such as Java Block/Item*/
+		folder: string
+		namespace: string
+		/** Texture ID or key, used by some formats. By default this is a number that increases with every texture that is added */
+		id: string
+		/** Whether the texture is used for the models particle system. Used by some formats such as Java Block/Item */
+		particle: boolean
+		render_mode: 'default' | 'emissive' | 'additive' | 'layered' | string
+		render_sides: 'auto' | 'front' | 'double' | string
+		pbr_channel: 'color' | 'normal' | 'height' | 'mer'
 
-	getUndoCopy(): Texture
+		/** Texture animation frame time */
+		frame_time: number
+		frame_order_type: 'custom' | 'loop' | 'backwards' | 'back_and_forth'
+		/** Custom frame order */
+		frame_order: string
+		/** Interpolate between frames */
+		frame_interpolate: boolean
 
-	static all: Texture[]
-	static getDefault(): Texture
-}
-/**
- * Saves all textures
- * @param lazy If true, the texture isn't saved if it doesn't have a local file to save to
- */
-declare function saveTextures(lazy?: boolean): void
-/**
- * Update the draggable/sortable functionality of the texture list
- */
-declare function loadTextureDraggable(): void
-/**
- * Unselect all textures
- */
-declare function unselectTextures(): void
+		/** HTML-style source of the texture's displayed data. Can be a path (desktop app only), or a base64 data URL */
+		source: string
+		selected?: boolean
+		show_icon: boolean
+		error: number
+		/** Whether the texture is visible. Used for layered textures mode */
+		visible: boolean
 
-/**
- * An Int Matrix holds an int (unsigned 8 bit) for each pixel in a matrix, via array. The override property can be used to set an override value for the entire area. This is used for texture selections.
- */
-declare class IntMatrix {
-	constructor(width: number, height: number)
-	width: number
-	height: number
-	array: null | Int8Array
-	/**
-	 * The override can be set to true to indicate that the whole texture is selected, or false, which indicates that nothing is selected. Null indicates a custom selection
-	 */
-	override: boolean | null
-	/**
-	 * True if there is a custom selection
-	 */
-	readonly is_custom: boolean
-	/**
-	 * The array does not exist by default to save memory, this activates it.
-	 */
-	activate(): void
-	/**
-	 * Get the value at the specified pixel
-	 * @param x X coordinate
-	 * @param y Y coordinate
-	 * @returns The value of the targeted pixel
-	 */
-	get(x: number, y: number): number | boolean
-	/**
-	 * Test whether painting is allowed at a specific pixel
-	 * @param x X coordinate
-	 * @param y Y coordinate
-	 * @returns Boolean or value of the pixel
-	 */
-	allow(x: number, y: number): number | boolean
-	/**
-	 * Get the value at the specified pixel directly without override and bounds check
-	 * @param x X coordinate
-	 * @param y Y coordinate
-	 * @returns
-	 */
-	getDirect(x: number, y: number): number
-	/**
-	 * Return the smallest possible rectangle that contains all of the selection
-	 * @param respect_empty If true, if there is no selection, the bounding box will still cover the entire area
-	 */
-	getBoundingRect(respect_empty: boolean): Rectangle
-	/**
-	 * Checks whether a selection is present and contains selected pixels
-	 */
-	hasSelection(): boolean
-	/**
-	 * Set the value at a specified pixel
-	 * @param {*} x X coordinate
-	 * @param {*} y Y coordinate
-	 * @param {number} value
-	 */
-	set(x: number, y: number, value: number): void
-	/**
-	 * If there was a selection, whether override or not, clear it
-	 */
-	clear(): void
-	/**
-	 * Change override mode
-	 * @param {true|false|null} value
-	 * @returns
-	 */
-	setOverride(value: boolean | null): void
-	/**
-	 * Change the size of the matrix. Unless using overrides, the selection gets lost.
-	 * @param {number} width
-	 * @param {number} height
-	 * @returns {boolean} Whether the size had to be changed
-	 */
-	changeSize(width: number, height: number): void
-	/**
-	 * Run a method on each pixel, whether selected or not
-	 * @param callback Function to run per pixel
-	 */
-	forEachPixel(callback: (x: number, y: number, value: number, index: number) => void): void
-	/**
-	 * Shift custom selections by a specified offset
-	 * @param offset_x
-	 * @param offset_y
-	 */
-	translate(offset_x: number, offset_y: number): void
-	/**
-	 * Return the selection simplified into non-overlapping boxes. Boxes are [x, y, width, height].
-	 */
-	toBoxes(): [number, number, number, number][]
-	/**
-	 * Mask the provided canvas using the selection
-	 * @param ctx Canvas 2D context
-	 * @param offset Position offset of the canvas, e. g. when using a layer
-	 */
-	maskCanvas(ctx: CanvasRenderingContext2D, offset: ArrayVector2): void
-}
+		width: number
+		height: number
+		uv_width: number
+		uv_height: number
+		currentFrame: number
+		saved: boolean
+		/**
+		 * Whether the latest version of the texture is currently loaded from and linked to a file on disk, or held in memory as bitmap data
+		 * @deprecated Use texture.internal instead
+		 */
+		mode: 'link' | 'bitmap'
+		/**
+		 * If true, the texture is loaded internally. If false, the texture is loaded directly from a file
+		 */
+		internal: boolean
+		uuid: UUID
 
-/**
- * Handles playback of animated textures
- */
-declare namespace TextureAnimator {
-	const isPlaying: boolean
-	const interval: any
-	function start(): void
-	function stop(): void
-	function toggle(): void
-	function updateSpeed(): void
-	function nextFrame(): void
-	function reset(): void
-	function updateButton(): void
+		/**
+		 * Texture selection in paint mode
+		 */
+		selection: IntMatrix
+		layers: TextureLayer[]
+		layers_enabled: boolean
+		/**
+		 * The UUID of the project to sync the texture to
+		 */
+		sync_to_project: UUID | ''
+
+		/**
+		 * The texture's associated canvas. Since 4.9, this is the main source of truth for textures in internal mode.
+		 */
+		canvas: HTMLCanvasElement
+		/**
+		 * The 2D context of the texture's associated canvas.
+		 */
+		ctx: CanvasRenderingContext2D
+		/**
+		 * Texture image element
+		 */
+		img: HTMLImageElement
+
+		relative_path?: string
+		get material(): THREE.ShaderMaterial
+		set material(value: THREE.ShaderMaterial)
+
+		getErrorMessage(): string
+		extend(data: TextureData): this
+
+		/**
+		 * Get the UV width of the texture if the format uses per texture UV size, otherwise get the project texture width
+		 */
+		getUVWidth(): number
+		/**
+		 * Get the UV height of the texture if the format uses per texture UV size, otherwise get the project texture height
+		 */
+		getUVHeight(): number
+		getUndoCopy(bitmap?: boolean): any
+		getSaveCopy(bitmap?: boolean): any
+		/**
+		 * Start listening for changes to the linked file. Desktop only
+		 */
+		startWatcher(): void
+		/**
+		 * Stop listening for changes to the linked file. Desktop only
+		 */
+		stopWatcher(): void
+		/**
+		 * Generate the Java Block/Item folder property from the file path
+		 */
+		generateFolder(): void
+		/**
+		 * Loads the texture from it's current source
+		 * @param cb Callback function
+		 */
+		load(cb?: () => {}): this
+		fromJavaLink(link: string, path_array: string[]): this
+		fromFile(file: { name: string; content?: string; path: string }): this
+		fromPath(path: string): this
+		/**
+		 * Loads file content **only**.
+		 *
+		 * Does not read `png.mcmeta`, or attempt to overwrite an existing texture in the project with the same name.
+		 *
+		 * Used internally when loading `.bbmodel` files
+		 * @param path
+		 */
+		loadContentFromPath(path: string): this
+		fromDataURL(data_url: string): this
+		fromDefaultPack(): true | undefined
+		/**
+		 * Loads the default white error texture
+		 * @param error_id Sets the error ID of the texture
+		 */
+		loadEmpty(error_id?: number): this
+
+		updateSource(dataUrl: string): this
+		updateMaterial(): this
+
+		/**
+		 * Opens a dialog to replace the texture with another file
+		 * @param force If true, no warning appears of the texture has unsaved changes
+		 */
+		reopen(force: boolean): void
+		/**
+		 * Reloads the texture. Only works in the desktop app
+		 */
+		reloadTexture(): void
+		/**
+		 * Get the material that the texture displays. When previewing PBR, this will return the shared PBR material
+		 */
+		getMaterial(): THREE.ShaderMaterial | THREE.MeshStandardMaterial
+		/**
+		 * Get the texture's own material
+		 */
+		getOwnMaterial(): THREE.ShaderMaterial
+		/**
+		 * Selects the texture
+		 * @param event Click event during selection
+		 */
+		select(event?: Event): this
+		/**
+		 * Adds texture to the textures list and initializes it
+		 * @param undo If true, an undo point is created
+		 */
+		add(undo?: boolean): Texture
+		/**
+		 * Removes the texture
+		 * @param no_update If true, the texture is silently removed. The interface is not updated, no undo point is created
+		 */
+		remove(no_update?: boolean): void
+		toggleVisibility(): this
+		enableParticle(): this
+		/**
+		 * Enables 'particle' on this texture if it is not enabled on any other texture
+		 */
+		fillParticle(): this
+		/**
+		 * Applies the texture to the selected elements
+		 * @param all If true, the texture is applied to all faces of the elements. If 'blank', the texture is only applied to blank faces
+		 */
+		apply(all?: true | false | 'blank'): this
+		/**
+		 * Shows the texture file in the file explorer
+		 */
+		openFolder(): this
+		/**
+		 * Opens the texture in the configured image editor
+		 */
+		openEditor(): this
+		showContextMenu(event: MouseEvent): void
+		openMenu(): void
+		resizeDialog(): this
+		/**
+		 * Scroll the texture list to this texture
+		 */
+		scrollTo(): void
+		save(as?: any): this
+		/**
+		 * Returns the content of the texture as PNG as a base64 encoded string
+		 */
+		getBase64(): string
+		/**
+		 * Returns the content of the texture as PNG as a base64 encoded data URL
+		 */
+		getDataURL(): string
+		/**
+		 * Wrapper to do edits to the texture.
+		 * @param callback
+		 * @param options Editing options
+		 */
+		edit(
+			callback?: (instance: HTMLCanvasElement | any) => void | HTMLCanvasElement,
+			options?: TextureEditOptions
+		): void
+		menu: Menu
+		/**
+		 * Get the selected layer. If no layer is selected, returns the bottom layer
+		 */
+		getActiveLayer(): TextureLayer
+		activateLayers(undo?: boolean): void
+		/**
+		 * Turns the texture selection into a layer
+		 * @param undo Whether to create an undo entry
+		 * @param clone When true, the selection is copied into the new layer and also left on the original layer
+		 */
+		selectionToLayer(undo?: boolean, clone?: boolean): void
+		javaTextureLink(): string
+
+		getMCMetaContent(): {
+			animation?: {
+				frametime: number
+				width?: number
+				height?: number
+				interpolate?: boolean
+				frames?: number[]
+			}
+		}
+		getAnimationFrameIndices(): number[]
+
+		exportEmissionMap(): void
+
+		convertToInternal(data_url?: string): this
+		/**
+		 * Redraws the texture content from the layers
+		 * @param update_data_url If true, the texture source gets updated as well. This is slower, but is necessary at the end of an edit. During an edit, to preview changes, this can be false
+		 */
+		updateLayerChanges(update_data_url?: boolean): void
+		/**
+		 * Update everything after a content edit to the texture or one of the layers. Updates the material, the layers, marks the texture as unsaved, syncs changes to other projects
+		 */
+		updateChangesAfterEdit(): void
+		/**
+		 * Update the attached img element with the content from the texture's canvas
+		 */
+		updateImageFromCanvas(): void
+		/**
+		 * If layers are enabled, returns the active layer, otherwise returns the texture. Either way, the 'canvas', 'ctx', and 'offset' properties can be used from the returned object
+		 */
+		getActiveCanvas(): Texture | TextureLayer
+		/**
+		 * When editing the same texture in different tabs (via Edit In Blockbench option), sync changes that were made to the texture to other projects
+		 */
+		syncToOtherProject(): this
+
+		getUndoCopy(): Texture
+
+		static all: Texture[]
+		static getDefault(): Texture
+	}
+	/**
+	 * Saves all textures
+	 * @param lazy If true, the texture isn't saved if it doesn't have a local file to save to
+	 */
+	function saveTextures(lazy?: boolean): void
+	/**
+	 * Update the draggable/sortable functionality of the texture list
+	 */
+	function loadTextureDraggable(): void
+	/**
+	 * Unselect all textures
+	 */
+	function unselectTextures(): void
+
+	/**
+	 * An Int Matrix holds an int (unsigned 8 bit) for each pixel in a matrix, via array. The override property can be used to set an override value for the entire area. This is used for texture selections.
+	 */
+	class IntMatrix {
+		constructor(width: number, height: number)
+		width: number
+		height: number
+		array: null | Int8Array
+		/**
+		 * The override can be set to true to indicate that the whole texture is selected, or false, which indicates that nothing is selected. Null indicates a custom selection
+		 */
+		override: boolean | null
+		/**
+		 * True if there is a custom selection
+		 */
+		readonly is_custom: boolean
+		/**
+		 * The array does not exist by default to save memory, this activates it.
+		 */
+		activate(): void
+		/**
+		 * Get the value at the specified pixel
+		 * @param x X coordinate
+		 * @param y Y coordinate
+		 * @returns The value of the targeted pixel
+		 */
+		get(x: number, y: number): number | boolean
+		/**
+		 * Test whether painting is allowed at a specific pixel
+		 * @param x X coordinate
+		 * @param y Y coordinate
+		 * @returns Boolean or value of the pixel
+		 */
+		allow(x: number, y: number): number | boolean
+		/**
+		 * Get the value at the specified pixel directly without override and bounds check
+		 * @param x X coordinate
+		 * @param y Y coordinate
+		 * @returns
+		 */
+		getDirect(x: number, y: number): number
+		/**
+		 * Return the smallest possible rectangle that contains all of the selection
+		 * @param respect_empty If true, if there is no selection, the bounding box will still cover the entire area
+		 */
+		getBoundingRect(respect_empty: boolean): Rectangle
+		/**
+		 * Checks whether a selection is present and contains selected pixels
+		 */
+		hasSelection(): boolean
+		/**
+		 * Set the value at a specified pixel
+		 * @param {*} x X coordinate
+		 * @param {*} y Y coordinate
+		 * @param {number} value
+		 */
+		set(x: number, y: number, value: number): void
+		/**
+		 * If there was a selection, whether override or not, clear it
+		 */
+		clear(): void
+		/**
+		 * Change override mode
+		 * @param {true|false|null} value
+		 * @returns
+		 */
+		setOverride(value: boolean | null): void
+		/**
+		 * Change the size of the matrix. Unless using overrides, the selection gets lost.
+		 * @param {number} width
+		 * @param {number} height
+		 * @returns {boolean} Whether the size had to be changed
+		 */
+		changeSize(width: number, height: number): void
+		/**
+		 * Run a method on each pixel, whether selected or not
+		 * @param callback Function to run per pixel
+		 */
+		forEachPixel(callback: (x: number, y: number, value: number, index: number) => void): void
+		/**
+		 * Shift custom selections by a specified offset
+		 * @param offset_x
+		 * @param offset_y
+		 */
+		translate(offset_x: number, offset_y: number): void
+		/**
+		 * Return the selection simplified into non-overlapping boxes. Boxes are [x, y, width, height].
+		 */
+		toBoxes(): [number, number, number, number][]
+		/**
+		 * Mask the provided canvas using the selection
+		 * @param ctx Canvas 2D context
+		 * @param offset Position offset of the canvas, e. g. when using a layer
+		 */
+		maskCanvas(ctx: CanvasRenderingContext2D, offset: ArrayVector2): void
+	}
+
+	/**
+	 * Handles playback of animated textures
+	 */
+	namespace TextureAnimator {
+		const isPlaying: boolean
+		const interval: any
+		function start(): void
+		function stop(): void
+		function toggle(): void
+		function updateSpeed(): void
+		function nextFrame(): void
+		function reset(): void
+		function updateButton(): void
+	}
 }

--- a/types/undo.d.ts
+++ b/types/undo.d.ts
@@ -107,7 +107,6 @@ type UndoEntry = {
 	time: number
 }
 
-
 declare class UndoSystem {
 	constructor()
 	/**
@@ -191,4 +190,3 @@ Undo.finishEdit('Add new cubes', {elements: [new_cube, other_cube]});
 ```
  */
 declare let Undo: UndoSystem
-


### PR DESCRIPTION
## Notes
- The commit called "Add `Texture._static` types" looks scary because A: Some lines got moved around in the file between our repos somehow, and B: I had to wrap the file in `declare global { ... }` to allow importing `FSWatcher`. As adding imports to change the file's default context from global to module.

    The important changes made to `types/textures.d.ts` in that commit (other than the above changes) are as follows:
    - ### Make `Texture.material` a get / set pair.
        Several of my plugins, including Animated Java, need to modify this property, and it's actual implementation [here](https://github.com/JannisX11/blockbench/blob/368efc7c8275d11fac355efa90720ebcd850f3b8/js/texturing/textures.js#L335) includes a setter.
        ```diff
        - readonly material: THREE.ShaderMaterial
        + get material(): THREE.ShaderMaterial
        + set material(THREE.ShaderMaterial)
        ```
    - ### Added `Texture.loadContentFromPath()`
        ```diff
       +/**
		+ * Loads file content **only**.
		+ *
		+ * Does not read `png.mcmeta`, or attempt to overwrite an existing texture in the project with the same name.
		+ *
		+ * Used internally when loading `.bbmodel` files
		+ * @param path
		+ */
		+loadContentFromPath(path: string): this
	        ```

Please open a discussion if there's anything I've changed here that seems wrong, or that you disagree with.